### PR TITLE
Trigger service error

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -11,10 +11,11 @@ if [[ $# -lt 1 ]]; then
 fi
 
 TARGET_HOST=$1
+readonly TARGET_ARCH=armv7-unknown-linux-musleabihf
 readonly TARGET_PATH=/home/pi/tc2-agent
-readonly SOURCE_PATH=./target/aarch64-unknown-linux-musl/release/tc2-agent
-readonly DEB_SOURCE_DIR=./target/aarch64-unknown-linux-musl/debian/
-readonly TARGET_ARCH=aarch64-unknown-linux-musl
+readonly SOURCE_PATH=./target/${TARGET_ARCH}/release/tc2-agent
+readonly DEB_SOURCE_DIR=./target/${TARGET_ARCH}/debian/
+
 
 DEB_OPTION=false
 WIFI_OPTION=false

--- a/src/main.rs
+++ b/src/main.rs
@@ -563,7 +563,7 @@ fn main() {
     let mut frame_acquire = !initial_config.is_audio_device();
 
     // We want real-time priority for all the work we do.
-    let _ = thread::Builder::new().name("frame-acquire".to_string()).spawn_with_priority(ThreadPriority::Max, move |result| {
+    let handle = thread::Builder::new().name("frame-acquire".to_string()).spawn_with_priority(ThreadPriority::Max, move |result| {
         assert!(result.is_ok(), "Thread must have permissions to run with realtime priority, run as root user");
 
         // 65K buffer that we won't fully use at the moment.
@@ -1174,7 +1174,12 @@ fn main() {
         }
         info!("Exiting gracefully");
         Ok::<(), Error>(())
-    }).unwrap().join();
+    }).unwrap();
+
+    if let Err(e) = handle.join() {
+        eprintln!("Thread panicked: {:?}", e);
+        std::process::exit(1);
+    }
 }
 
 pub const CRC_AUG_CCITT: Algorithm<u16> = Algorithm {


### PR DESCRIPTION
Update deploy script.

When failing in the `frame-acquire` thread the tc2-agent system service would be "Deactivated successfully." instead of failing. This change will now cause it to fail. Meaning that `service-reporter` will see it and log it as an system error event.