### PR TITLE
Recording offload improvements

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ target = "aarch64-unknown-linux-musl"
 
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-gnu-gcc"
+# applies to target-specific builds
+# rPi3
+rustflags = "-C target-cpu=cortex-a53"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           toolchain: 1.88.0
           override: true
+          components: rustfmt, clippy
 
       - name: Display Rust and Cargo version
         run: |
@@ -66,6 +67,12 @@ jobs:
 
       - name: Build the project
         run: cargo build --release --target=aarch64-unknown-linux-musl
+
+      - name: Run fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Create Debian package
         run: cargo deb --target=aarch64-unknown-linux-musl --output tc2-agent_${GITHUB_REF#refs/tags/v}_arm64.deb

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.81.0
+          toolchain: 1.88.0
           override: true
 
       - name: Display Rust and Cargo version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc2-agent"
-version = "0.0.0-snapshot"  # Updated by travis on release.
+version = "0.0.0-snapshot"  # Updated by CI on release.
 edition = "2024"
 description = "Program to interface between the Raspberry Pi and the RP2040 in the DOC AI Cam"
 license = "GPL v3.0"
@@ -31,10 +31,6 @@ rustbus = "0.19.3"
 sha256 = "1.5.0"
 sysinfo = "0.35.2"
 
-[target.aarch64-unknown-linux-musl]
-# applies to target-specific builds
-# rPi3
-rustflags = "-C target-cpu=cortex-a53"
 
 [package.metadata.deb]
 name = "tc2-agent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tc2-agent"
 version = "0.0.0-snapshot"  # Updated by travis on release.
-edition = "2021"
+edition = "2024"
 description = "Program to interface between the Raspberry Pi and the RP2040 in the DOC AI Cam"
 license = "GPL v3.0"
 authors = ["Cacophony Developers <coredev@cacophony.org.nz>"]
@@ -29,7 +29,7 @@ sun-times = "0.2.0"
 louvre = "0.2.1"
 rustbus = "0.19.3"
 sha256 = "1.5.0"
-sysinfo = "0.34.2"
+sysinfo = "0.35.2"
 
 [target.aarch64-unknown-linux-musl]
 # applies to target-specific builds

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+msrv = "1.88.0"
+too-many-arguments-threshold = 15

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.88.0"  # If changing this then also change it in .github/workflows/release.yaml rust toolchain
+targets = ["aarch64-unknown-linux-musl"]

--- a/src/camera_transfer_state.rs
+++ b/src/camera_transfer_state.rs
@@ -91,7 +91,7 @@ pub fn enter_camera_transfer_loop(
 ) {
     let spi_speed = spi_speed_mhz * 1_000_000;
     // rPi3 can handle 12Mhz (@600Mhz), may need to back it off a little to have some slack.
-    info!("Initialising SPI at {}Mhz", spi_speed_mhz);
+    info!("Initialising SPI at {spi_speed_mhz}Mhz");
     let mut spi = match Spi::new(Bus::Spi0, SlaveSelect::Ss0, spi_speed, Mode::Mode3) {
         Ok(spi) => spi,
         Err(e) => {
@@ -283,7 +283,7 @@ pub fn enter_camera_transfer_loop(
                                 error!("Unable to set pi ping interrupt: {e}");
                                 process::exit(1);
                             }
-                            info!("Pin interrupts failed,trying again {}", e);
+                            info!("Pin interrupts failed, trying again {e}");
                             sleep(Duration::from_millis(100));
                         }
                     }
@@ -325,7 +325,7 @@ pub fn enter_camera_transfer_loop(
                     // Just log the *first* time the header integrity check fails in a session.
                     if !header_integrity_check_has_failed {
                         header_integrity_check_has_failed = true;
-                        warn!("Header integrity check failed {:?}", header_slice);
+                        warn!("Header integrity check failed {header_slice:?}");
                         // We still need to make sure we read out all the bytes?
                     }
 
@@ -356,7 +356,7 @@ pub fn enter_camera_transfer_loop(
                     //  spin in this state pretty aggressively.
                     match last_unknown_transfer_warning {
                         None => {
-                            warn!("unknown transfer type {}", transfer_type);
+                            warn!("unknown transfer type {transfer_type}");
                             last_unknown_transfer_warning = Some((transfer_type, Instant::now()))
                         }
                         Some((transfer_t, time)) => {
@@ -387,7 +387,7 @@ pub fn enter_camera_transfer_loop(
                     LittleEndian::write_u16(&mut return_payload_buf[6..8], crc);
 
                     if transfer_type == CAMERA_STARTUP_HANDSHAKE {
-                        info!("Got camera startup handshake {:?}", chunk);
+                        info!("Got camera startup handshake {chunk:?}");
                         // Write all the info we need about the device:
                         let force_offload_files_now =
                             pending_forced_offload_request.take().is_some();
@@ -461,9 +461,8 @@ pub fn enter_camera_transfer_loop(
                                     info!(
                                         "{num_files_to_offload} file(s) to offload \
                                             totalling {estimated_offload_mb}MB \
-                                            estimated offload time {:.2} mins. \
-                                            Events to offload {num_events_to_offload}",
-                                        estimated_offload_time_seconds
+                                            estimated offload time {estimated_offload_time_seconds:.2} mins. \
+                                            Events to offload {num_events_to_offload}"
                                     );
                                 } else if num_events_to_offload > 0 {
                                     info!("Events to offload {num_events_to_offload}");
@@ -499,8 +498,7 @@ pub fn enter_camera_transfer_loop(
                                         "Got thermal startup info: \
                                         radiometry enabled: {radiometry_enabled}, \
                                         lepton serial #{lepton_serial_number} \
-                                        recording mode {:?}",
-                                        recording_mode
+                                        recording mode {recording_mode:?}"
                                     );
                                 } else {
                                     info!("Got audio mode startup");
@@ -549,8 +547,7 @@ pub fn enter_camera_transfer_loop(
                                                 *alarm_time = event_payload as i64;
                                             } else {
                                                 warn!(
-                                                    "Wakeup alarm from event was invalid {}",
-                                                    event_payload
+                                                    "Wakeup alarm from event was invalid {event_payload}"
                                                 );
                                             }
                                         } else if let LoggerEventKind::SetThermalAlarm(alarm_time) =
@@ -562,8 +559,7 @@ pub fn enter_camera_transfer_loop(
                                                 *alarm_time = event_payload as i64;
                                             } else {
                                                 warn!(
-                                                    "Wakeup alarm from event was invalid {}",
-                                                    event_payload
+                                                    "Wakeup alarm from event was invalid {event_payload}"
                                                 );
                                             }
                                         } else if let LoggerEventKind::Rp2040MissedAudioAlarm(
@@ -576,8 +572,7 @@ pub fn enter_camera_transfer_loop(
                                                 *alarm_time = event_payload as i64;
                                             } else {
                                                 warn!(
-                                                    "Missed alarm from event was invalid {}",
-                                                    event_payload
+                                                    "Missed alarm from event was invalid {event_payload}"
                                                 );
                                             }
                                         } else if let LoggerEventKind::ToldRpiToWake(reason) =
@@ -589,8 +584,7 @@ pub fn enter_camera_transfer_loop(
                                                 *reason = wake_reason;
                                             } else {
                                                 warn!(
-                                                    "Told rpi to wake invalid reason {}",
-                                                    event_payload
+                                                    "Told rpi to wake invalid reason {event_payload}"
                                                 );
                                             }
                                         } else if matches!(
@@ -654,10 +648,10 @@ pub fn enter_camera_transfer_loop(
                                         let event = LoggerEvent::new(event_kind, event_timestamp);
                                         event.log(&mut dbus_conn, payload_json);
                                     } else {
-                                        warn!("Event had invalid timestamp {}", event_timestamp);
+                                        warn!("Event had invalid timestamp {event_timestamp}");
                                     }
                                 } else {
-                                    warn!("Unknown logger event kind {}", event_kind);
+                                    warn!("Unknown logger event kind {event_kind}");
                                 }
                             }
                             CAMERA_BEGIN_FILE_TRANSFER => {
@@ -688,11 +682,9 @@ pub fn enter_camera_transfer_loop(
                                             / Instant::now().duration_since(start).as_secs_f32()
                                             / (1024.0 * 1024.0);
                                         info!(
-                                            "Transferring part #{} {:?} for {} bytes, {}MB/s",
-                                            part_count,
+                                            "Transferring part #{part_count} {:?} for {} bytes, {megabytes_per_second}MB/s",
                                             Instant::now().duration_since(start),
                                             file.len() + chunk.len(),
-                                            megabytes_per_second
                                         );
                                     }
                                     part_count += 1;
@@ -729,10 +721,9 @@ pub fn enter_camera_transfer_loop(
                                         / Instant::now().duration_since(start).as_secs_f32()
                                         / (1024.0 * 1024.0);
                                     info!(
-                                        "End file transfer, took {:?} for {} bytes, {}MB/s",
+                                        "End file transfer, took {:?} for {} bytes, {megabytes_per_second}MB/s",
                                         Instant::now().duration_since(start),
                                         file.len() + chunk.len(),
-                                        megabytes_per_second
                                     );
                                     part_count = 0;
                                     file.extend_from_slice(chunk);
@@ -778,7 +769,7 @@ pub fn enter_camera_transfer_loop(
                             }
                             _ => {
                                 if num_bytes != 0 {
-                                    warn!("Unhandled transfer type, {:#x}", transfer_type)
+                                    warn!("Unhandled transfer type, {transfer_type:#x}")
                                 }
                             }
                         }
@@ -788,7 +779,7 @@ pub fn enter_camera_transfer_loop(
                 } else {
                     spi.read(&mut raw_read_buffer[2066..num_bytes + header_length])
                         .map_err(|e| {
-                            error!("SPI read error: {:?}", e);
+                            error!("SPI read error: {e:?}");
 
                             // TODO: Shutdown gracefully?
 
@@ -807,7 +798,7 @@ pub fn enter_camera_transfer_loop(
                     back.replace(Some(frame));
                     if !got_first_frame {
                         got_first_frame = true;
-                        info!("Got first frame from rp2040, got startup info {}", got_startup_info);
+                        info!("Got first frame from rp2040, got startup info {got_startup_info}");
                     }
                     // FIXME: Should is_recording bit only be set in high power mode?
                     // FIXME: Check this out.
@@ -855,12 +846,12 @@ fn maybe_make_test_audio_recording(
         let mut inner_recording_state = recording_state.clone();
         let _ = thread::spawn(move || {
             let dbus_session_path = get_system_bus_path().unwrap_or_else(|e| {
-                error!("Error getting system DBus: {}", e);
+                error!("Error getting system DBus: {e}");
                 process::exit(1);
             });
             match DuplexConn::connect_to_bus(dbus_session_path, true) {
                 Err(e) => {
-                    error!("Error connecting to system DBus: {}", e);
+                    error!("Error connecting to system DBus: {e}");
                     process::exit(1);
                 }
                 Ok(mut conn) => {
@@ -920,12 +911,12 @@ fn maybe_make_test_thermal_recording(
         let mut inner_recording_state = recording_state.clone();
         let _ = thread::spawn(move || {
             let dbus_session_path = get_system_bus_path().unwrap_or_else(|e| {
-                error!("Error getting system DBus: {}", e);
+                error!("Error getting system DBus: {e}");
                 process::exit(1);
             });
             match DuplexConn::connect_to_bus(dbus_session_path, true) {
                 Err(e) => {
-                    error!("Error connecting to system DBus: {}", e);
+                    error!("Error connecting to system DBus: {e}");
                     process::exit(1);
                 }
                 Ok(mut conn) => {

--- a/src/camera_transfer_state.rs
+++ b/src/camera_transfer_state.rs
@@ -696,6 +696,7 @@ pub fn enter_camera_transfer_loop(
                                         },
                                     );
                                 } else {
+                                    // FIXME: This might actually break forced offload.
                                     warn!("Trying to continue file with no open file");
                                     if !got_startup_info
                                         && recording_state.safe_to_restart_rp2040(&mut dbus_conn)

--- a/src/camera_transfer_state.rs
+++ b/src/camera_transfer_state.rs
@@ -1,7 +1,7 @@
 use crate::cptv_frame_dispatch::FRAME_BUFFER;
 use crate::dbus_attiny_i2c::{exit_cleanly, process_interrupted};
 
-use crate::device_config::{check_for_device_config_changes, DeviceConfig};
+use crate::device_config::{DeviceConfig, check_for_device_config_changes};
 use crate::event_logger::{LoggerEvent, LoggerEventKind, WakeReason};
 use crate::frame_socket_server::FrameSocketServerMessage;
 use crate::program_rp2040::program_rp2040;
@@ -9,20 +9,20 @@ use crate::recording_state::RecordingMode;
 use crate::save_audio::save_audio_file_to_disk;
 use crate::save_cptv::save_cptv_file_to_disk;
 use crate::utils::u8_slice_as_u16_slice;
-use crate::{RecordingState, AUDIO_SHEBANG, EXPECTED_RP2040_FIRMWARE_VERSION, FRAME_LENGTH};
+use crate::{AUDIO_SHEBANG, EXPECTED_RP2040_FIRMWARE_VERSION, FRAME_LENGTH, RecordingState};
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use chrono::{DateTime, Utc};
 use chrono_tz::Tz::Pacific__Auckland;
-use crc::{Crc, CRC_16_XMODEM};
+use crc::{CRC_16_XMODEM, Crc};
 use log::{error, info, warn};
 use rppal::gpio::Trigger;
 use rppal::spi::{BitOrder, Bus, Mode, Polarity, SlaveSelect, Spi};
 use rustbus::connection::Timeout;
-use rustbus::{get_system_bus_path, DuplexConn};
+use rustbus::{DuplexConn, get_system_bus_path};
 use std::ops::Not;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
-use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 use std::{process, thread};
@@ -35,6 +35,7 @@ pub const CAMERA_END_FILE_TRANSFER: u8 = 0x5;
 pub const CAMERA_BEGIN_AND_END_FILE_TRANSFER: u8 = 0x6;
 pub const CAMERA_GET_MOTION_DETECTION_MASK: u8 = 0x7;
 pub const CAMERA_SEND_LOGGER_EVENT: u8 = 0x8;
+pub const CAMERA_STARTUP_HANDSHAKE: u8 = 0x9;
 
 pub struct CameraHandshakeInfo {
     pub radiometry_enabled: bool,
@@ -54,6 +55,7 @@ pub enum ExtTransferMessage {
     BeginAndEndFileTransfer = 0x6,
     GetMotionDetectionMask = 0x7,
     SendLoggerEvent = 0x8,
+    CameraStartupHandshake = 0x9,
 }
 
 impl TryFrom<u8> for ExtTransferMessage {
@@ -70,6 +72,7 @@ impl TryFrom<u8> for ExtTransferMessage {
             0x6 => Ok(BeginAndEndFileTransfer),
             0x7 => Ok(GetMotionDetectionMask),
             0x8 => Ok(SendLoggerEvent),
+            0x9 => Ok(CameraStartupHandshake),
             _ => Err(()),
         }
     }
@@ -179,10 +182,7 @@ pub fn enter_camera_transfer_loop(
         }
         if !recording_state.is_recording() && rp2040_needs_reset {
             let date = chrono::Local::now();
-            warn!(
-                "Requesting reset of rp2040 at {}",
-                date.with_timezone(&Pacific__Auckland)
-            );
+            warn!("Requesting reset of rp2040 at {}", date.with_timezone(&Pacific__Auckland));
             rp2040_needs_reset = false;
             got_startup_info = false;
             is_audio_device = device_config.is_audio_device();
@@ -199,451 +199,449 @@ pub fn enter_camera_transfer_loop(
             }
         }
         let poll_result = pin.poll_interrupt(false, Some(Duration::from_millis(2000)));
-        if let Ok(_pin_level) = poll_result {
-            if _pin_level.is_some() {
-                {
-                    drop(pin);
-                    let output_pin = match gpio.get(7) {
-                        Ok(pin) => pin.into_output_low(),
-                        Err(e) => {
-                            error!(
-                                "Failed to get pi ping interrupt pin ({e}), \
+        if let Ok(_pin_level) = poll_result
+            && _pin_level.is_some()
+        {
+            {
+                drop(pin);
+                let output_pin = match gpio.get(7) {
+                    Ok(pin) => pin.into_output_low(),
+                    Err(e) => {
+                        error!(
+                            "Failed to get pi ping interrupt pin ({e}), \
         is 'dtoverlay=spi0-1cs,cs0_pin=8' set in your config.txt?"
-                            );
-                            process::exit(1);
-                        }
-                    };
-                    drop(output_pin);
-                    pin = match gpio.get(7) {
-                        Ok(pin) => pin.into_input(),
-                        Err(e) => {
-                            error!(
-                                "Failed to get pi ping interrupt pin ({e}), \
+                        );
+                        process::exit(1);
+                    }
+                };
+                drop(output_pin);
+                pin = match gpio.get(7) {
+                    Ok(pin) => pin.into_input(),
+                    Err(e) => {
+                        error!(
+                            "Failed to get pi ping interrupt pin ({e}), \
         is 'dtoverlay=spi0-1cs,cs0_pin=8' set in your config.txt?"
-                            );
-                            process::exit(1);
-                        }
-                    };
+                        );
+                        process::exit(1);
+                    }
+                };
 
-                    pin.clear_interrupt()
-                        .map_err(|e| {
-                            error!("Unable to clear pi ping interrupt pin: {e}");
-                            process::exit(1);
-                        })
-                        .unwrap();
+                pin.clear_interrupt()
+                    .map_err(|e| {
+                        error!("Unable to clear pi ping interrupt pin: {e}");
+                        process::exit(1);
+                    })
+                    .unwrap();
 
-                    // this seems to happen when save_audio fails...
-                    let attempts = 100;
-                    for i in 0..attempts{
-                        let res = pin.set_interrupt(Trigger::RisingEdge, None);
-                        match res{
-                            Ok(())=> break,
-                            Err(e)=>{
-                                if i == attempts-1 {
-                                    error!("Unable to set pi ping interrupt: {e}");
-                                    process::exit(1);
-                                }
-                                info!("Pin interrupts failed,trying again {}",e);
-                                sleep(Duration::from_millis(100));
+                // this seems to happen when save_audio fails...
+                let attempts = 100;
+                for i in 0..attempts {
+                    let res = pin.set_interrupt(Trigger::RisingEdge, None);
+                    match res {
+                        Ok(()) => break,
+                        Err(e) => {
+                            if i == attempts - 1 {
+                                error!("Unable to set pi ping interrupt: {e}");
+                                process::exit(1);
                             }
+                            info!("Pin interrupts failed,trying again {}", e);
+                            sleep(Duration::from_millis(100));
                         }
                     }
                 }
+            }
 
-                spi.read(&mut raw_read_buffer[..2066]).unwrap();
-                {
-                    let header_slice = &raw_read_buffer[..header_length];
-                    let transfer_type = header_slice[0];
-                    let transfer_type_dup = header_slice[1];
-                    let mut num_bytes = LittleEndian::read_u32(&header_slice[2..6]) as usize;
-                    let num_bytes_dup = LittleEndian::read_u32(&header_slice[6..10]) as usize;
-                    num_bytes = num_bytes.min(max_size);
-                    let crc_from_remote = LittleEndian::read_u16(&header_slice[10..12]);
-                    let crc_from_remote_dup = LittleEndian::read_u16(&header_slice[12..14]);
-                    let crc_from_remote_inv = LittleEndian::read_u16(&header_slice[14..16]);
-                    let crc_from_remote_inv_dup = LittleEndian::read_u16(&header_slice[16..=17]);
-                    let transfer_type_check = transfer_type == transfer_type_dup;
-                    let mut transfer_block = 0;
-                    let is_file_transfer_message = transfer_type_check
-                        && transfer_type >= CAMERA_BEGIN_FILE_TRANSFER
-                        && transfer_type <= CAMERA_BEGIN_AND_END_FILE_TRANSFER;
-                    let is_file_transfer_progress_message = transfer_type_check
-                        && (transfer_type == CAMERA_BEGIN_FILE_TRANSFER
-                            || transfer_type == CAMERA_END_FILE_TRANSFER);
-                    let header_crc_check = if is_file_transfer_progress_message {
-                        transfer_block = crc_from_remote_dup;
+            spi.read(&mut raw_read_buffer[..2066]).unwrap();
+            {
+                let header_slice = &raw_read_buffer[..header_length];
+                let transfer_type = header_slice[0];
+                let transfer_type_dup = header_slice[1];
+                let mut num_bytes = LittleEndian::read_u32(&header_slice[2..6]) as usize;
+                let num_bytes_dup = LittleEndian::read_u32(&header_slice[6..10]) as usize;
+                num_bytes = num_bytes.min(max_size);
+                let crc_from_remote = LittleEndian::read_u16(&header_slice[10..12]);
+                let crc_from_remote_dup = LittleEndian::read_u16(&header_slice[12..14]);
+                let crc_from_remote_inv = LittleEndian::read_u16(&header_slice[14..16]);
+                let crc_from_remote_inv_dup = LittleEndian::read_u16(&header_slice[16..=17]);
+                let transfer_type_check = transfer_type == transfer_type_dup;
+                let mut transfer_block = 0;
+                let is_file_transfer_message = (CAMERA_BEGIN_FILE_TRANSFER
+                    ..=CAMERA_BEGIN_AND_END_FILE_TRANSFER)
+                    .contains(&transfer_type);
+                let is_file_transfer_progress_message = transfer_type_check
+                    && (transfer_type == CAMERA_BEGIN_FILE_TRANSFER
+                        || transfer_type == CAMERA_END_FILE_TRANSFER);
+                let header_crc_check = if is_file_transfer_progress_message {
+                    transfer_block = crc_from_remote_dup;
 
-                        crc_from_remote_inv_dup == crc_from_remote_inv
-                            && crc_from_remote_inv.not() == crc_from_remote
-                    } else {
-                        crc_from_remote == crc_from_remote_dup
-                            && crc_from_remote_inv_dup == crc_from_remote_inv
-                            && crc_from_remote_inv.not() == crc_from_remote
-                    };
-                    let num_bytes_check = num_bytes == num_bytes_dup;
-                    if !num_bytes_check || !header_crc_check || !transfer_type_check {
-                        // Just log the *first* time the header integrity check fails in a session.
-                        if !header_integrity_check_has_failed {
-                            header_integrity_check_has_failed = true;
-                            warn!("Header integrity check failed {:?}", &header_slice[..]);
-                            // We still need to make sure we read out all the bytes?
-                        }
-
-                        LittleEndian::write_u16(&mut return_payload_buf[4..6], 0);
-                        LittleEndian::write_u16(&mut return_payload_buf[6..8], 0);
-                        spi.write(&return_payload_buf).unwrap();
-                        if process_interrupted(&sig_term, &mut dbus_conn) {
-                            break 'transfer;
-                        }
-                        continue 'transfer;
-                    }
-                    if num_bytes == 0 {
-                        // warn!("zero-sized payload");
-                        LittleEndian::write_u16(&mut return_payload_buf[4..6], 0);
-                        LittleEndian::write_u16(&mut return_payload_buf[6..8], 0);
-                        spi.write(&return_payload_buf).unwrap();
-                        if process_interrupted(&sig_term, &mut dbus_conn) {
-                            break 'transfer;
-                        }
-                        continue 'transfer;
-                    }
-                    if transfer_type < CAMERA_CONNECT_INFO
-                        || transfer_type > CAMERA_SEND_LOGGER_EVENT
-                    {
-                        warn!("unknown transfer type {}", transfer_type);
-                        LittleEndian::write_u16(&mut return_payload_buf[4..6], 0);
-                        LittleEndian::write_u16(&mut return_payload_buf[6..8], 0);
-                        spi.write(&return_payload_buf).unwrap();
-                        if process_interrupted(&sig_term, &mut dbus_conn) {
-                            break 'transfer;
-                        }
-                        continue 'transfer;
+                    crc_from_remote_inv_dup == crc_from_remote_inv
+                        && crc_from_remote_inv.not() == crc_from_remote
+                } else {
+                    crc_from_remote == crc_from_remote_dup
+                        && crc_from_remote_inv_dup == crc_from_remote_inv
+                        && crc_from_remote_inv.not() == crc_from_remote
+                };
+                let num_bytes_check = num_bytes == num_bytes_dup;
+                if !num_bytes_check || !header_crc_check || !transfer_type_check {
+                    // Just log the *first* time the header integrity check fails in a session.
+                    if !header_integrity_check_has_failed {
+                        header_integrity_check_has_failed = true;
+                        warn!("Header integrity check failed {:?}", header_slice);
+                        // We still need to make sure we read out all the bytes?
                     }
 
-                    if transfer_type != CAMERA_RAW_FRAME_TRANSFER {
-                        if transfer_type == CAMERA_BEGIN_FILE_TRANSFER {
-                            start = Instant::now();
-                        }
-                        let chunk = &raw_read_buffer[header_length..header_length + num_bytes];
-                        // Write back the crc we calculated.
-                        let crc = crc_check.checksum(chunk);
-                        LittleEndian::write_u16(&mut return_payload_buf[4..6], crc);
-                        LittleEndian::write_u16(&mut return_payload_buf[6..8], crc);
+                    LittleEndian::write_u16(&mut return_payload_buf[4..6], 0);
+                    LittleEndian::write_u16(&mut return_payload_buf[6..8], 0);
+                    spi.write(&return_payload_buf).unwrap();
+                    if process_interrupted(&sig_term, &mut dbus_conn) {
+                        break 'transfer;
+                    }
+                    continue 'transfer;
+                }
+                if num_bytes == 0 {
+                    // warn!("zero-sized payload");
+                    LittleEndian::write_u16(&mut return_payload_buf[4..6], 0);
+                    LittleEndian::write_u16(&mut return_payload_buf[6..8], 0);
+                    spi.write(&return_payload_buf).unwrap();
+                    if process_interrupted(&sig_term, &mut dbus_conn) {
+                        break 'transfer;
+                    }
+                    continue 'transfer;
+                }
+                if !(CAMERA_CONNECT_INFO..=CAMERA_STARTUP_HANDSHAKE).contains(&transfer_type) {
+                    warn!("unknown transfer type {}", transfer_type);
+                    LittleEndian::write_u16(&mut return_payload_buf[4..6], 0);
+                    LittleEndian::write_u16(&mut return_payload_buf[6..8], 0);
+                    spi.write(&return_payload_buf).unwrap();
+                    if process_interrupted(&sig_term, &mut dbus_conn) {
+                        break 'transfer;
+                    }
+                    continue 'transfer;
+                }
 
-                        if transfer_type == CAMERA_CONNECT_INFO {
-                            info!("Got camera connect info {:?}", chunk);
-                            // Write all the info we need about the device:
-                            device_config.write_to_slice(&mut return_payload_buf[8..]);
-                            info!("Sending camera device config to rp2040");
-                        } else if transfer_type == CAMERA_GET_MOTION_DETECTION_MASK {
-                            let piece_number = &chunk[0];
-                            //info!("Got request for mask piece number {}", piece_number);
-                            let piece = device_config.mask_piece(*piece_number as usize);
+                if transfer_type != CAMERA_RAW_FRAME_TRANSFER {
+                    if transfer_type == CAMERA_BEGIN_FILE_TRANSFER {
+                        start = Instant::now();
+                    }
+                    let chunk = &raw_read_buffer[header_length..header_length + num_bytes];
+                    // Write back the crc we calculated.
+                    let crc = crc_check.checksum(chunk);
+                    LittleEndian::write_u16(&mut return_payload_buf[4..6], crc);
+                    LittleEndian::write_u16(&mut return_payload_buf[6..8], crc);
 
-                            let mut piece_with_length = [0u8; 101];
-                            piece_with_length[0] = piece.len() as u8;
-                            piece_with_length[1..1 + piece.len()].copy_from_slice(piece);
-                            let crc = crc_check.checksum(&piece_with_length[0..1 + piece.len()]);
-                            LittleEndian::write_u16(&mut return_payload_buf[8..10], crc);
-                            //info!("Sending piece({}) {:?}", piece.len(), piece_with_length);
-                            return_payload_buf[10..10 + piece.len() + 1]
-                                .copy_from_slice(&piece_with_length);
+                    if transfer_type == CAMERA_STARTUP_HANDSHAKE {
+                        info!("Got camera startup handshake {:?}", chunk);
+                        // Write all the info we need about the device:
+                        // TODO: Set byte/bit to indicate offload preference.
+                        let prefer_not_to_offload_files_now = false;
+                        device_config.write_to_slice(
+                            &mut return_payload_buf[8..],
+                            prefer_not_to_offload_files_now,
+                        );
+                        info!("Sending camera device config to rp2040");
+                    } else if transfer_type == CAMERA_GET_MOTION_DETECTION_MASK {
+                        let piece_number = &chunk[0];
+                        let piece = device_config.mask_piece(*piece_number as usize);
+                        let mut piece_with_length = [0u8; 101];
+                        piece_with_length[0] = piece.len() as u8;
+                        piece_with_length[1..1 + piece.len()].copy_from_slice(piece);
+                        let crc = crc_check.checksum(&piece_with_length[0..1 + piece.len()]);
+                        LittleEndian::write_u16(&mut return_payload_buf[8..10], crc);
+                        return_payload_buf[10..10 + piece.len() + 1]
+                            .copy_from_slice(&piece_with_length);
+                    }
+                    // Always write the return buffer
+                    spi.write(&return_payload_buf).unwrap();
+                    if crc == crc_from_remote {
+                        if is_file_transfer_progress_message {
+                            recording_state.update_offload_progress(transfer_block);
+                        } else if !is_file_transfer_message && recording_state.is_offloading() {
+                            recording_state.end_offload();
                         }
-                        // Always write the return buffer
-                        spi.write(&return_payload_buf).unwrap();
-                        if crc == crc_from_remote {
-                            if is_file_transfer_progress_message {
-                                recording_state.update_offload_progress(transfer_block);
-                            } else if !is_file_transfer_message && recording_state.is_offloading() {
-                                recording_state.end_offload();
+
+                        match transfer_type {
+                            CAMERA_STARTUP_HANDSHAKE => {
+                                firmware_version = LittleEndian::read_u32(&chunk[4..8]);
+
+                                let num_files_to_offload = LittleEndian::read_u32(&chunk[8..12]);
+                                let num_blocks_to_offload = LittleEndian::read_u32(&chunk[12..16]);
+                                let num_events_to_offload = LittleEndian::read_u32(&chunk[0..4]);
+                                recording_state.set_offload_totals(
+                                    num_files_to_offload,
+                                    num_blocks_to_offload,
+                                    num_events_to_offload,
+                                );
+
+                                if firmware_version != EXPECTED_RP2040_FIRMWARE_VERSION {
+                                    exit_cleanly(&mut dbus_conn);
+                                    info!(
+                                        "Unsupported firmware version, expected \
+                                        {EXPECTED_RP2040_FIRMWARE_VERSION}, got \
+                                        {firmware_version}. Will reprogram RP2040."
+                                    );
+                                    let e = program_rp2040();
+                                    if e.is_err() {
+                                        warn!("Failed to reprogram rp2040: {}", e.unwrap_err());
+                                        panic!("Exit");
+                                    }
+                                    process::exit(0);
+                                }
+                                info!(
+                                    "Got startup handshake: \
+                                        firmware version: {firmware_version}"
+                                );
+                                let estimated_offload_mb =
+                                    (num_blocks_to_offload * 128) as f32 / 1024.0;
+                                let estimated_offload_time_seconds =
+                                    (estimated_offload_mb * 2.0) / 60.0;
+                                info!(
+                                    "{num_files_to_offload} file(s) to offload  \
+                                        totalling {estimated_offload_mb}MB \
+                                        estimated offload time {:.2} mins
+                                        Events to offload {num_events_to_offload}",
+                                    estimated_offload_time_seconds
+                                );
+                                // Terminate any existing file download.
+                                let in_progress_file_transfer = file_download.take();
+                                if let Some(file) = in_progress_file_transfer {
+                                    warn!(
+                                        "Aborting in progress file transfer with {} bytes",
+                                        file.len()
+                                    );
+                                }
+                                let _ =
+                                    camera_handshake_channel_tx.send(FrameSocketServerMessage {
+                                        camera_handshake_info: None,
+                                        camera_file_transfer_in_progress: false,
+                                    });
                             }
-
-                            match transfer_type {
-                                CAMERA_CONNECT_INFO => {
+                            CAMERA_CONNECT_INFO => {
+                                let recording_mode = if LittleEndian::read_u32(&chunk[12..16]) != 0
+                                {
+                                    RecordingMode::Audio
+                                } else {
+                                    RecordingMode::Thermal
+                                };
+                                recording_state.set_mode(recording_mode);
+                                if recording_mode == RecordingMode::Thermal {
                                     radiometry_enabled = LittleEndian::read_u32(&chunk[0..4]) == 2;
-                                    firmware_version = LittleEndian::read_u32(&chunk[4..8]);
                                     lepton_serial_number =
                                         format!("{}", LittleEndian::read_u32(&chunk[8..12]));
                                     got_startup_info = true;
-                                    if firmware_version != EXPECTED_RP2040_FIRMWARE_VERSION {
-                                        exit_cleanly(&mut dbus_conn);
-                                        info!(
-                                            "Unsupported firmware version, expected {}, got {}. Will reprogram RP2040.",
-                                            EXPECTED_RP2040_FIRMWARE_VERSION, firmware_version
-                                        );
-                                        let e = program_rp2040();
-                                        if e.is_err() {
-                                            warn!("Failed to reprogram rp2040: {}", e.unwrap_err());
-                                            panic!("Exit");
-                                        }
-                                        process::exit(0);
-                                    }
-
-                                    let recording_mode =
-                                        if LittleEndian::read_u32(&chunk[12..16]) != 0 {
-                                            RecordingMode::Audio
-                                        } else {
-                                            RecordingMode::Thermal
-                                        };
-                                    recording_state.set_mode(recording_mode);
                                     info!(
-                                        "Got startup info: \
-                                    radiometry enabled: {radiometry_enabled}, \
-                                    firmware version: {firmware_version}, \
-                                    lepton serial #{lepton_serial_number} \
-                                    recording mode {:?}",
+                                        "Got thermal startup info: \
+                                        radiometry enabled: {radiometry_enabled}, \
+                                        lepton serial #{lepton_serial_number} \
+                                        recording mode {:?}",
                                         recording_mode
                                     );
+                                } else {
+                                    info!("Got audio mode startup");
+                                }
 
-                                    if device_config.use_low_power_mode()
-                                        && !radiometry_enabled
-                                        && !device_config.is_audio_device()
-                                    {
-                                        exit_cleanly(&mut dbus_conn);
-                                        error!(
-                                            "Low power mode is currently only supported on \
+                                if device_config.use_low_power_mode()
+                                    && !radiometry_enabled
+                                    && !device_config.is_audio_device()
+                                {
+                                    exit_cleanly(&mut dbus_conn);
+                                    error!(
+                                        "Low power mode is currently only supported on \
                                         lepton sensors with radiometry or audio device, exiting."
-                                        );
-                                        panic!("Exit");
-                                    }
-                                    // Terminate any existing file download.
-                                    let in_progress_file_transfer = file_download.take();
-                                    if let Some(file) = in_progress_file_transfer {
-                                        warn!(
-                                            "Aborting in progress file transfer with {} bytes",
-                                            file.len()
-                                        );
-                                    }
-                                    let _ = camera_handshake_channel_tx.send(
-                                        FrameSocketServerMessage {
-                                            camera_handshake_info: None,
-                                            camera_file_transfer_in_progress: false,
-                                        },
+                                    );
+                                    panic!("Exit");
+                                }
+                                // Terminate any existing file download.
+                                let in_progress_file_transfer = file_download.take();
+                                if let Some(file) = in_progress_file_transfer {
+                                    warn!(
+                                        "Aborting in progress file transfer with {} bytes",
+                                        file.len()
                                     );
                                 }
-                                CAMERA_SEND_LOGGER_EVENT => {
-                                    let event_kind = LittleEndian::read_u16(&chunk[0..2]);
-                                    let mut event_timestamp =
-                                        LittleEndian::read_u64(&chunk[2..2 + 8]);
-                                    let event_payload = LittleEndian::read_u64(&chunk[10..18]);
-                                    if let Ok(mut event_kind) =
-                                        LoggerEventKind::try_from(event_kind)
+                                let _ =
+                                    camera_handshake_channel_tx.send(FrameSocketServerMessage {
+                                        camera_handshake_info: None,
+                                        camera_file_transfer_in_progress: false,
+                                    });
+                            }
+                            CAMERA_SEND_LOGGER_EVENT => {
+                                let event_kind = LittleEndian::read_u16(&chunk[0..2]);
+                                let mut event_timestamp = LittleEndian::read_i64(&chunk[2..2 + 8]);
+                                let event_payload = LittleEndian::read_u64(&chunk[10..18]);
+                                if let Ok(mut event_kind) = LoggerEventKind::try_from(event_kind) {
+                                    recording_state.completed_event_offload();
+                                    if let Some(mut time) =
+                                        DateTime::from_timestamp_micros(event_timestamp)
                                     {
-                                        if let Some(mut time) =
-                                            DateTime::from_timestamp_micros(event_timestamp as i64)
+                                        if let LoggerEventKind::SetAlarm(alarm_time) =
+                                            &mut event_kind
                                         {
-                                            if let LoggerEventKind::SetAlarm(alarm_time) =
-                                                &mut event_kind
-                                            {
-                                                if DateTime::from_timestamp_micros(
-                                                    event_payload as i64,
-                                                )
+                                            if DateTime::from_timestamp_micros(event_payload as i64)
                                                 .is_some()
-                                                {
-                                                    *alarm_time = event_payload;
-                                                } else {
-                                                    warn!(
-                                                        "Wakeup alarm from event was invalid {}",
-                                                        event_payload
-                                                    );
-                                                }
-                                            } else if let LoggerEventKind::Rp2040MissedAudioAlarm(
-                                                alarm_time,
-                                            ) = &mut event_kind
                                             {
-                                                if DateTime::from_timestamp_micros(
-                                                    event_payload as i64,
-                                                )
-                                                .is_some()
-                                                {
-                                                    *alarm_time = event_payload;
-                                                } else {
-                                                    warn!(
-                                                        "Missed alarm from event was invalid {}",
-                                                        event_payload
-                                                    );
-                                                }
-                                            } else if let LoggerEventKind::ToldRpiToWake(reason) =
-                                                &mut event_kind
-                                            {
-                                                if let Ok(wake_reason) =
-                                                    WakeReason::try_from(event_payload as u8)
-                                                {
-                                                    *reason = wake_reason;
-                                                } else {
-                                                    warn!(
-                                                        "Told rpi to wake invalid reason {}",
-                                                        event_payload
-                                                    );
-                                                }
-                                            } else if let LoggerEventKind::RtcCommError =
-                                                &mut event_kind
-                                            {
-                                                if event_timestamp == 0 {
-                                                    time = chrono::Local::now().with_timezone(&Utc);
-                                                    event_timestamp =
-                                                        time.timestamp_micros() as u64;
-                                                }
-                                            } else if let LoggerEventKind::LostFrames(lost_frames) =
-                                                &mut event_kind
-                                            {
-                                                *lost_frames = event_payload as u64;
+                                                *alarm_time = event_payload as i64;
+                                            } else {
+                                                warn!(
+                                                    "Wakeup alarm from event was invalid {}",
+                                                    event_payload
+                                                );
                                             }
-                                            let payload_json =
-                                                if let LoggerEventKind::SavedNewConfig = event_kind
-                                                {
-                                                    // If we get saved new config, the rp2040 would have just been
-                                                    // restarted after the config change, so we can log the current
-                                                    // config in relation to that event.
-                                                    let json_inner = format!(
-                                                        r#""continuous-recorder": {},
+                                        } else if let LoggerEventKind::Rp2040MissedAudioAlarm(
+                                            alarm_time,
+                                        ) = &mut event_kind
+                                        {
+                                            if DateTime::from_timestamp_micros(event_payload as i64)
+                                                .is_some()
+                                            {
+                                                *alarm_time = event_payload as i64;
+                                            } else {
+                                                warn!(
+                                                    "Missed alarm from event was invalid {}",
+                                                    event_payload
+                                                );
+                                            }
+                                        } else if let LoggerEventKind::ToldRpiToWake(reason) =
+                                            &mut event_kind
+                                        {
+                                            if let Ok(wake_reason) =
+                                                WakeReason::try_from(event_payload as u8)
+                                            {
+                                                *reason = wake_reason;
+                                            } else {
+                                                warn!(
+                                                    "Told rpi to wake invalid reason {}",
+                                                    event_payload
+                                                );
+                                            }
+                                        } else if let LoggerEventKind::RtcCommError =
+                                            &mut event_kind
+                                        {
+                                            if event_timestamp == 0 {
+                                                time = chrono::Local::now().with_timezone(&Utc);
+                                                event_timestamp = time.timestamp_micros();
+                                            }
+                                        } else if let LoggerEventKind::LostFrames(lost_frames) =
+                                            &mut event_kind
+                                        {
+                                            *lost_frames = event_payload;
+                                        }
+                                        let payload_json = if let LoggerEventKind::SavedNewConfig =
+                                            event_kind
+                                        {
+                                            // If we get saved new config, the rp2040 would have just been
+                                            // restarted after the config change, so we can log the current
+                                            // config in relation to that event.
+                                            let json_inner = format!(
+                                                r#""continuous-recorder": {},
                                                         "use-low-power-mode": {},
                                                         "start-recording": "{:?}",
                                                         "stop-recording": "{:?}",
                                                         "location": "({}, {}, {})"
                                                         "#,
-                                                        device_config.is_continuous_recorder(),
-                                                        device_config.use_low_power_mode(),
-                                                        device_config.recording_window().0,
-                                                        device_config.recording_window().1,
-                                                        device_config.lat_lng().0,
-                                                        device_config.lat_lng().1,
-                                                        device_config
-                                                            .location_altitude()
-                                                            .unwrap_or(0.0)
-                                                    );
-                                                    let json =
-                                                        String::from(format!("{{{}}}", json_inner));
-                                                    Some(json)
-                                                } else {
-                                                    None
-                                                };
-                                            info!(
-                                                "Got logger event {:?} at {}",
-                                                event_kind,
-                                                time.with_timezone(&Pacific__Auckland)
+                                                device_config.is_continuous_recorder(),
+                                                device_config.use_low_power_mode(),
+                                                device_config.recording_window().0,
+                                                device_config.recording_window().1,
+                                                device_config.lat_lng().0,
+                                                device_config.lat_lng().1,
+                                                device_config.location_altitude().unwrap_or(0.0)
                                             );
-                                            let event =
-                                                LoggerEvent::new(event_kind, event_timestamp);
-                                            event.log(&mut dbus_conn, payload_json);
+                                            let json = format!("{{{json_inner}}}");
+                                            Some(json)
                                         } else {
-                                            warn!(
-                                                "Event had invalid timestamp {}",
-                                                event_timestamp
-                                            );
-                                        }
+                                            None
+                                        };
+                                        info!(
+                                            "Got logger event {:?} at {}",
+                                            event_kind,
+                                            time.with_timezone(&Pacific__Auckland)
+                                        );
+                                        let event = LoggerEvent::new(event_kind, event_timestamp);
+                                        event.log(&mut dbus_conn, payload_json);
                                     } else {
-                                        warn!("Unknown logger event kind {}", event_kind);
+                                        warn!("Event had invalid timestamp {}", event_timestamp);
                                     }
+                                } else {
+                                    warn!("Unknown logger event kind {}", event_kind);
                                 }
-                                CAMERA_BEGIN_FILE_TRANSFER => {
-                                    if file_download.is_some() {
-                                        warn!("Trying to begin file without ending current");
+                            }
+                            CAMERA_BEGIN_FILE_TRANSFER => {
+                                if file_download.is_some() {
+                                    warn!("Trying to begin file without ending current");
+                                }
+                                info!("Begin file transfer");
+                                // Open new file transfer
+                                part_count += 1;
+                                // If we have to grow this Vec once it gets big it can be slow and interrupt the transfer.
+                                // TODO: Should really be able to recover from that though!
+                                let mut file = Vec::with_capacity(150_000_000);
+                                file.extend_from_slice(chunk);
+                                file_download = Some(file);
+                                let _ =
+                                    camera_handshake_channel_tx.send(FrameSocketServerMessage {
+                                        camera_handshake_info: None,
+                                        camera_file_transfer_in_progress: true,
+                                    });
+                            }
+                            CAMERA_RESUME_FILE_TRANSFER => {
+                                if let Some(file) = &mut file_download {
+                                    // Continue current file transfer
+                                    //println!("Continue file transfer");
+                                    if part_count % 100 == 0 {
+                                        let megabytes_per_second = (file.len() + chunk.len())
+                                            as f32
+                                            / Instant::now().duration_since(start).as_secs_f32()
+                                            / (1024.0 * 1024.0);
+                                        info!(
+                                            "Transferring part #{} {:?} for {} bytes, {}MB/s",
+                                            part_count,
+                                            Instant::now().duration_since(start),
+                                            file.len() + chunk.len(),
+                                            megabytes_per_second
+                                        );
                                     }
-                                    info!("Begin file transfer");
-                                    // Open new file transfer
                                     part_count += 1;
-                                    // If we have to grow this Vec once it gets big it can be slow and interrupt the transfer.
-                                    // TODO: Should really be able to recover from that though!
-                                    let mut file = Vec::with_capacity(150_000_000);
-                                    file.extend_from_slice(&chunk);
-                                    file_download = Some(file);
+                                    file.extend_from_slice(chunk);
                                     let _ = camera_handshake_channel_tx.send(
                                         FrameSocketServerMessage {
                                             camera_handshake_info: None,
                                             camera_file_transfer_in_progress: true,
                                         },
                                     );
-                                }
-                                CAMERA_RESUME_FILE_TRANSFER => {
-                                    if let Some(file) = &mut file_download {
-                                        // Continue current file transfer
-                                        //println!("Continue file transfer");
-                                        if part_count % 100 == 0 {
-                                            let megabytes_per_second = (file.len() + chunk.len())
-                                                as f32
-                                                / Instant::now()
-                                                    .duration_since(start)
-                                                    .as_secs_f32()
-                                                / (1024.0 * 1024.0);
-                                            info!(
-                                                "Transferring part #{} {:?} for {} bytes, {}MB/s",
-                                                part_count,
-                                                Instant::now().duration_since(start),
-                                                file.len() + chunk.len(),
-                                                megabytes_per_second
-                                            );
-                                        }
-                                        part_count += 1;
-                                        file.extend_from_slice(&chunk);
-                                        let _ = camera_handshake_channel_tx.send(
-                                            FrameSocketServerMessage {
-                                                camera_handshake_info: None,
-                                                camera_file_transfer_in_progress: true,
-                                            },
-                                        );
-                                    } else {
-                                        warn!("Trying to continue file with no open file");
-                                        if !got_startup_info {
-                                            if recording_state
-                                                .safe_to_restart_rp2040(&mut dbus_conn)
-                                            {
-                                                let date = chrono::Local::now();
-                                                error!(
-                                                    "1) Requesting reset of rp2040 to \
+                                } else {
+                                    warn!("Trying to continue file with no open file");
+                                    if !got_startup_info
+                                        && recording_state.safe_to_restart_rp2040(&mut dbus_conn)
+                                    {
+                                        let date = chrono::Local::now();
+                                        error!(
+                                            "1) Requesting reset of rp2040 to \
                                                 force handshake, {}",
-                                                    date.format("%Y-%m-%d--%H:%M:%S")
-                                                );
-                                                let _ = restart_rp2040_channel_tx.send(true);
-                                            }
-                                        }
+                                            date.format("%Y-%m-%d--%H:%M:%S")
+                                        );
+                                        let _ = restart_rp2040_channel_tx.send(true);
                                     }
                                 }
-                                CAMERA_END_FILE_TRANSFER => {
-                                    // End current file transfer
-                                    if !file_download.is_some() {
-                                        warn!("Trying to end file with no open file");
-                                    }
-                                    if let Some(mut file) = file_download.take() {
-                                        // Continue current file transfer
-                                        let megabytes_per_second = (file.len() + chunk.len())
-                                            as f32
-                                            / Instant::now().duration_since(start).as_secs_f32()
-                                            / (1024.0 * 1024.0);
-                                        info!(
-                                            "End file transfer, took {:?} for {} bytes, {}MB/s",
-                                            Instant::now().duration_since(start),
-                                            file.len() + chunk.len(),
-                                            megabytes_per_second
-                                        );
-                                        part_count = 0;
-                                        file.extend_from_slice(&chunk);
-                                        let shebang = LittleEndian::read_u16(&file[0..2]);
-                                        if shebang == AUDIO_SHEBANG {
-                                            save_audio_file_to_disk(file, device_config.clone());
-                                        } else {
-                                            save_cptv_file_to_disk(file, device_config.output_dir())
-                                        }
-                                        let _ = camera_handshake_channel_tx.send(
-                                            FrameSocketServerMessage {
-                                                camera_handshake_info: None,
-                                                camera_file_transfer_in_progress: false,
-                                            },
-                                        );
-                                    } else {
-                                        warn!("Trying to end file with no open file");
-                                    }
+                            }
+                            CAMERA_END_FILE_TRANSFER => {
+                                // End current file transfer
+                                if file_download.is_none() {
+                                    warn!("Trying to end file with no open file");
                                 }
-                                CAMERA_BEGIN_AND_END_FILE_TRANSFER => {
-                                    if file_download.is_some() {
-                                        info!(
-                                            "Trying to begin (and end) file without ending current"
-                                        );
-                                    }
-                                    // Open and end new file transfer
+                                if let Some(mut file) = file_download.take() {
+                                    // Continue current file transfer
+                                    let megabytes_per_second = (file.len() + chunk.len()) as f32
+                                        / Instant::now().duration_since(start).as_secs_f32()
+                                        / (1024.0 * 1024.0);
+                                    info!(
+                                        "End file transfer, took {:?} for {} bytes, {}MB/s",
+                                        Instant::now().duration_since(start),
+                                        file.len() + chunk.len(),
+                                        megabytes_per_second
+                                    );
                                     part_count = 0;
-                                    let mut file = Vec::new();
-                                    file.extend_from_slice(&chunk);
+                                    file.extend_from_slice(chunk);
+                                    recording_state.completed_file_offload();
                                     let shebang = LittleEndian::read_u16(&file[0..2]);
                                     if shebang == AUDIO_SHEBANG {
                                         save_audio_file_to_disk(file, device_config.clone());
@@ -656,62 +654,84 @@ pub fn enter_camera_transfer_loop(
                                             camera_file_transfer_in_progress: false,
                                         },
                                     );
-                                }
-                                CAMERA_GET_MOTION_DETECTION_MASK => {
-                                    // Already handled
-                                }
-                                _ => {
-                                    if num_bytes != 0 {
-                                        warn!("Unhandled transfer type, {:#x}", transfer_type)
-                                    }
+                                } else {
+                                    warn!("Trying to end file with no open file");
                                 }
                             }
-                        } else {
-                            warn!("Crc check failed, remote was notified and will re-transmit");
+                            CAMERA_BEGIN_AND_END_FILE_TRANSFER => {
+                                if file_download.is_some() {
+                                    info!("Trying to begin (and end) file without ending current");
+                                }
+                                // Open and end new file transfer
+                                part_count = 0;
+                                let mut file = Vec::new();
+                                file.extend_from_slice(chunk);
+                                let shebang = LittleEndian::read_u16(&file[0..2]);
+                                if shebang == AUDIO_SHEBANG {
+                                    save_audio_file_to_disk(file, device_config.clone());
+                                } else {
+                                    save_cptv_file_to_disk(file, device_config.output_dir())
+                                }
+                                let _ =
+                                    camera_handshake_channel_tx.send(FrameSocketServerMessage {
+                                        camera_handshake_info: None,
+                                        camera_file_transfer_in_progress: false,
+                                    });
+                            }
+                            CAMERA_GET_MOTION_DETECTION_MASK => {
+                                // Already handled
+                            }
+                            _ => {
+                                if num_bytes != 0 {
+                                    warn!("Unhandled transfer type, {:#x}", transfer_type)
+                                }
+                            }
                         }
                     } else {
-                        spi.read(&mut raw_read_buffer[2066..num_bytes + header_length])
-                            .map_err(|e| {
-                                error!("SPI read error: {:?}", e);
-                                process::exit(1);
-                            })
-                            .unwrap();
-                        // Frame
-                        let mut frame = [0u8; FRAME_LENGTH];
-                        BigEndian::write_u16_into(
-                            u8_slice_as_u16_slice(
-                                &raw_read_buffer[header_length..header_length + FRAME_LENGTH],
-                            ),
-                            &mut frame,
-                        );
-                        let back = FRAME_BUFFER.get_back().lock().unwrap();
-                        back.replace(Some(frame));
-                        if !got_first_frame {
-                            got_first_frame = true;
-                            info!(
-                                "Got first frame from rp2040, got startup info {}",
-                                got_startup_info
-                            );
-                        }
-                        // FIXME: Should is_recording bit only be set in high power mode?
-                        let is_recording =
-                            crc_from_remote == 1 && !device_config.use_low_power_mode();
-                        recording_state.set_is_recording(is_recording);
-                        if !got_startup_info {
-                            warn!("Requesting reset of rp2040 to force handshake");
-                            rp2040_needs_reset = true;
-                        } else if !rp2040_needs_reset {
-                            FRAME_BUFFER.swap();
-                            let _ = camera_handshake_channel_tx.send(FrameSocketServerMessage {
-                                camera_handshake_info: Some(CameraHandshakeInfo {
-                                    radiometry_enabled,
-                                    is_recording: recording_state.is_recording(),
-                                    firmware_version,
-                                    camera_serial: lepton_serial_number.clone(),
-                                }),
-                                camera_file_transfer_in_progress: false,
-                            });
-                        }
+                        warn!("Crc check failed, remote was notified and will re-transmit");
+                    }
+                } else {
+                    spi.read(&mut raw_read_buffer[2066..num_bytes + header_length])
+                        .map_err(|e| {
+                            error!("SPI read error: {:?}", e);
+
+                            // TODO: Shutdown gracefully?
+
+                            process::exit(1);
+                        })
+                        .unwrap();
+                    // Frame
+                    let mut frame = [0u8; FRAME_LENGTH];
+                    BigEndian::write_u16_into(
+                        u8_slice_as_u16_slice(
+                            &raw_read_buffer[header_length..header_length + FRAME_LENGTH],
+                        ),
+                        &mut frame,
+                    );
+                    let back = FRAME_BUFFER.get_back().lock().unwrap();
+                    back.replace(Some(frame));
+                    if !got_first_frame {
+                        got_first_frame = true;
+                        info!("Got first frame from rp2040, got startup info {}", got_startup_info);
+                    }
+                    // FIXME: Should is_recording bit only be set in high power mode?
+                    // FIXME: Check this out.
+                    let is_recording = crc_from_remote == 1 && device_config.use_high_power_mode();
+                    recording_state.set_is_recording(is_recording);
+                    if !got_startup_info {
+                        warn!("Requesting reset of rp2040 to force handshake");
+                        rp2040_needs_reset = true;
+                    } else if !rp2040_needs_reset {
+                        FRAME_BUFFER.swap();
+                        let _ = camera_handshake_channel_tx.send(FrameSocketServerMessage {
+                            camera_handshake_info: Some(CameraHandshakeInfo {
+                                radiometry_enabled,
+                                is_recording: recording_state.is_recording(),
+                                firmware_version,
+                                camera_serial: lepton_serial_number.clone(),
+                            }),
+                            camera_file_transfer_in_progress: false,
+                        });
                     }
                 }
             }
@@ -727,70 +747,63 @@ fn maybe_make_test_audio_recording(
     restart_rp2040_channel_tx: &Sender<bool>,
     recording_state: &mut RecordingState,
 ) {
+    // FIXME: Is this correct?  Looks like the flag to take a test recording would just be pending?
+
     // If the rp2040 is making a recording, and a user test audio recording was requested,
     // do nothing.
 
     // If the user requested a test audio recording, trigger the test audio recording, and
     // launch a thread to track when that recording has completed.
-    if recording_state.user_requested_audio_recording() {
-        recording_state.sync_state_from_attiny(dbus_conn);
-        if !recording_state.is_recording()
-            && recording_state.request_audio_recording_from_rp2040(dbus_conn)
-        {
-            let _ = restart_rp2040_channel_tx.send(true);
-            info!("Telling rp2040 to take test recording and restarting");
-            let mut inner_recording_state = recording_state.clone();
-            let _ = thread::spawn(move || {
-                let dbus_session_path = get_system_bus_path().unwrap_or_else(|e| {
-                    error!("Error getting system DBus: {}", e);
+    if recording_state.user_requested_audio_recording()
+        && recording_state.request_audio_recording_from_rp2040(dbus_conn)
+    {
+        let _ = restart_rp2040_channel_tx.send(true);
+        info!("Telling rp2040 to take test recording and restarting");
+        let mut inner_recording_state = recording_state.clone();
+        let _ = thread::spawn(move || {
+            let dbus_session_path = get_system_bus_path().unwrap_or_else(|e| {
+                error!("Error getting system DBus: {}", e);
+                process::exit(1);
+            });
+            match DuplexConn::connect_to_bus(dbus_session_path, true) {
+                Err(e) => {
+                    error!("Error connecting to system DBus: {}", e);
                     process::exit(1);
-                });
-                match DuplexConn::connect_to_bus(dbus_session_path, true) {
-                    Err(e) => {
-                        error!("Error connecting to system DBus: {}", e);
+                }
+                Ok(mut conn) => {
+                    let _unique_name = conn.send_hello(Timeout::Infinite);
+                    if _unique_name.is_err() {
+                        error!(
+                            "Error getting handshake with system DBus: {}",
+                            _unique_name.err().unwrap()
+                        );
                         process::exit(1);
-                    }
-                    Ok(mut conn) => {
-                        let _unique_name = conn.send_hello(Timeout::Infinite);
-                        if _unique_name.is_err() {
-                            error!(
-                                "Error getting handshake with system DBus: {}",
-                                _unique_name.err().unwrap()
-                            );
-                            process::exit(1);
-                        } else {
-                            loop {
-                                // Re-sync our internal rp2040 state once every 1-2 seconds until
-                                // we see that the state has entered taking_test_audio_recording.
-                                inner_recording_state.sync_state_from_attiny(&mut conn);
-                                let sleep_duration_ms = if inner_recording_state.is_recording() {
-                                    2000
-                                } else {
-                                    1000
-                                };
-                                if inner_recording_state.is_taking_test_audio_recording() {
-                                    break;
-                                }
-                                sleep(Duration::from_millis(sleep_duration_ms));
+                    } else {
+                        loop {
+                            // Re-sync our internal rp2040 state once every 1-2 seconds until
+                            // we see that the state has entered taking_test_audio_recording.
+                            inner_recording_state.sync_state_from_attiny(&mut conn);
+                            let sleep_duration_ms =
+                                if inner_recording_state.is_recording() { 2000 } else { 1000 };
+                            if inner_recording_state.is_taking_test_audio_recording() {
+                                break;
                             }
-                            loop {
-                                // Now wait until we've exited taking_test_audio_recording.
-                                inner_recording_state.sync_state_from_attiny(&mut conn);
-                                let sleep_duration_ms = if inner_recording_state.is_recording() {
-                                    2000
-                                } else {
-                                    1000
-                                };
-                                if !inner_recording_state.is_taking_test_audio_recording() {
-                                    inner_recording_state.finished_taking_test_recording();
-                                    break;
-                                }
-                                sleep(Duration::from_millis(sleep_duration_ms));
+                            sleep(Duration::from_millis(sleep_duration_ms));
+                        }
+                        loop {
+                            // Now wait until we've exited taking_test_audio_recording.
+                            inner_recording_state.sync_state_from_attiny(&mut conn);
+                            let sleep_duration_ms =
+                                if inner_recording_state.is_recording() { 2000 } else { 1000 };
+                            if !inner_recording_state.is_taking_test_audio_recording() {
+                                inner_recording_state.finished_taking_test_recording();
+                                break;
                             }
+                            sleep(Duration::from_millis(sleep_duration_ms));
                         }
                     }
                 }
-            });
-        }
+            }
+        });
     }
 }

--- a/src/cptv_frame_dispatch.rs
+++ b/src/cptv_frame_dispatch.rs
@@ -1,6 +1,6 @@
+use crate::FRAME_LENGTH;
 use crate::double_buffer::DoubleBuffer;
 use crate::socket_stream::SocketStream;
-use crate::FRAME_LENGTH;
 
 pub type Frame = [u8; FRAME_LENGTH];
 pub static FRAME_BUFFER: DoubleBuffer = DoubleBuffer::new();
@@ -18,7 +18,7 @@ pub fn get_frame(is_recording: bool) -> Option<[u8; 39040]> {
     None
 }
 pub fn send_frame(fb: [u8; 39040], stream: &mut SocketStream) -> bool {
-    if let Err(_) = stream.write_all(&fb) {
+    if stream.write_all(&fb).is_err() {
         return false;
     }
     stream.flush().is_ok()

--- a/src/cptv_header.rs
+++ b/src/cptv_header.rs
@@ -2,7 +2,7 @@ use flate2::read::MultiGzDecoder;
 use log::warn;
 use nom::bytes::streaming::{tag, take};
 use nom::error::{ContextError, ErrorKind};
-use nom::number::streaming::{le_f32, le_u16, le_u32, le_u64, le_u8};
+use nom::number::streaming::{le_f32, le_u8, le_u16, le_u32, le_u64};
 use std::error::Error;
 use std::io::Read;
 
@@ -67,9 +67,10 @@ impl Cptv2Header {
     }
 }
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum CptvHeader {
     #[allow(unused)]
-    UNINITIALISED,
+    Uninitialised,
     V2(Cptv2Header),
 }
 
@@ -272,7 +273,7 @@ pub fn decode_cptv_header_streaming(cptv_bytes: &[u8]) -> Result<CptvHeader, Box
                     unzipped.extend_from_slice(&buffer[0..read]);
                 }
                 nom::Err::Failure(e) | nom::Err::Error(e) => {
-                    return Err(format!("Parse error, not a valid CPTV file ({:?})", e.code))?
+                    Err(format!("Parse error, not a valid CPTV file ({:?})", e.code))?;
                 }
             },
         }

--- a/src/cptv_header.rs
+++ b/src/cptv_header.rs
@@ -236,7 +236,7 @@ pub fn decode_cptv2_header(i: &[u8]) -> nom::IResult<&[u8], CptvHeader> {
                 meta.has_background_frame = has_background_frame == 1;
             }
             _ => {
-                warn!("Unknown header field type {}, {}", field, field_length);
+                warn!("Unknown header field type {field}, {field_length}");
             }
         }
     }

--- a/src/dbus_attiny_i2c.rs
+++ b/src/dbus_attiny_i2c.rs
@@ -8,7 +8,8 @@ use std::process;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
-
+pub const ATTINY_REG_TC2_AGENT_STATE: u8 = 0x07;
+pub const ATTINY_REG_VERSION: u8 = 0x01;
 const CRC_AUG_CCITT: Algorithm<u16> = Algorithm {
     width: 16,
     poly: 0x1021,
@@ -137,8 +138,10 @@ pub fn dbus_attiny_command_attempt(
     }
 }
 
-pub fn exit_cleanly(conn: &mut DuplexConn) {
-    let _ = dbus_write_attiny_command(conn, 0x07, 0x00);
+pub fn exit_cleanly(_conn: &mut DuplexConn) {
+    // NOTE: No longer sure this is correct.  If pi goes to sleep while rp2040 is doing its
+    //  thing, this could put the rp2040 in a weird state.
+    // let _ = dbus_write_attiny_command(conn, ATTINY_REG_TC2_AGENT_STATE, 0x00);
 }
 
 pub fn process_interrupted(term: &Arc<AtomicBool>, conn: &mut DuplexConn) -> bool {
@@ -152,11 +155,11 @@ pub fn process_interrupted(term: &Arc<AtomicBool>, conn: &mut DuplexConn) -> boo
 }
 
 pub fn read_tc2_agent_state(conn: &mut DuplexConn) -> Result<u8, &'static str> {
-    dbus_read_attiny_command(conn, 0x07)
+    dbus_read_attiny_command(conn, ATTINY_REG_TC2_AGENT_STATE)
 }
 
 pub fn read_attiny_firmware_version(conn: &mut DuplexConn) -> Result<u8, &'static str> {
-    dbus_read_attiny_command(conn, 0x01)
+    dbus_read_attiny_command(conn, ATTINY_REG_VERSION)
 }
 
 pub fn exit_if_attiny_version_is_not_as_expected(dbus_conn: &mut DuplexConn) {

--- a/src/dbus_attiny_i2c.rs
+++ b/src/dbus_attiny_i2c.rs
@@ -5,8 +5,8 @@ use log::error;
 use rustbus::connection::Timeout;
 use rustbus::{DuplexConn, MessageBuilder, MessageType};
 use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 const CRC_AUG_CCITT: Algorithm<u16> = Algorithm {
@@ -48,8 +48,8 @@ pub fn dbus_attiny_command(
                     return Err("Max attempts reached: failed to execute i2c dbus command");
                 }
                 error!(
-                    "Attempt {}/{} failed: {}. Retrying in {:?}...",
-                    attempt, max_attempts, e, retry_delay
+                    "Attempt to call command {} with value {:?} failed. {}/{}: {}. Retrying in {:?}...",
+                    command, value, attempt, max_attempts, e, retry_delay
                 );
                 std::thread::sleep(retry_delay);
             }
@@ -104,11 +104,7 @@ pub fn dbus_attiny_command_attempt(
                             let response = &message.get_buf()[4..][0..3];
                             let crc = Crc::<u16>::new(&CRC_AUG_CCITT).checksum(&response[0..1]);
                             let received_crc = BigEndian::read_u16(&response[1..=2]);
-                            if received_crc != crc {
-                                Err("CRC Mismatch")
-                            } else {
-                                Ok(response[0])
-                            }
+                            if received_crc != crc { Err("CRC Mismatch") } else { Ok(response[0]) }
                         } else {
                             // Check that the written value was actually written correctly.
                             let set_value = dbus_attiny_command(conn, command, None);

--- a/src/dbus_attiny_i2c.rs
+++ b/src/dbus_attiny_i2c.rs
@@ -49,8 +49,9 @@ pub fn dbus_attiny_command(
                     return Err("Max attempts reached: failed to execute i2c dbus command");
                 }
                 error!(
-                    "Attempt to call command {} with value {:?} failed. {}/{}: {}. Retrying in {:?}...",
-                    command, value, attempt, max_attempts, e, retry_delay
+                    "Attempt to call command {command} \
+                    with value {value:?} failed. {attempt}/{max_attempts}: {e}. \
+                    Retrying in {retry_delay:?}...",
                 );
                 std::thread::sleep(retry_delay);
             }
@@ -169,15 +170,15 @@ pub fn exit_if_attiny_version_is_not_as_expected(dbus_conn: &mut DuplexConn) {
             EXPECTED_ATTINY_FIRMWARE_VERSION => {}
             _ => {
                 error!(
-                    "Mismatched attiny firmware version, expected {}, got {}",
-                    EXPECTED_ATTINY_FIRMWARE_VERSION, version
+                    "Mismatched attiny firmware version, \
+                    expected {EXPECTED_ATTINY_FIRMWARE_VERSION}, got {version}",
                 );
                 exit_cleanly(dbus_conn);
                 process::exit(1);
             }
         },
         Err(msg) => {
-            error!("{}", msg);
+            error!("{msg}");
             exit_cleanly(dbus_conn);
             process::exit(1);
         }

--- a/src/dbus_managementd.rs
+++ b/src/dbus_managementd.rs
@@ -171,11 +171,11 @@ pub fn setup_dbus_managementd_recording_service(
         move |_| {
             let mut dbus_conn =
                 DuplexConn::connect_to_bus(session_path, false).unwrap_or_else(|e| {
-                    error!("Error connecting to system DBus: {}", e);
+                    error!("Error connecting to system DBus: {e}");
                     process::exit(1);
                 });
             let _name = dbus_conn.send_hello(Timeout::Infinite).unwrap_or_else(|e| {
-                error!("Error getting handshake with system DBus: {}", e);
+                error!("Error getting handshake with system DBus: {e}");
                 process::exit(1);
             });
             dbus_conn

--- a/src/dbus_managementd.rs
+++ b/src/dbus_managementd.rs
@@ -121,14 +121,29 @@ fn managementd_handler(
             Ok(Some(response))
         }
         "canceloffload" => {
-            let response = msg.dynheader.make_response();
-            // TODO: Make this work
+            let mut response = msg.dynheader.make_response();
+            // This needs to unset the offload bit in tc2-agent state,
+            // And then the rp2040 should pick this up and cancel offloading
+            // and offloads.
+            if recording_state_ctx.is_offloading() {
+                recording_state_ctx.request_offload_cancellation();
+                response.body.push_param("Requested offload cancellation")?;
+            } else {
+                response.body.push_param("No offload in progress")?;
+            }
+
             Ok(Some(response))
         }
         "forcerp2040offload" => {
             let mut response = msg.dynheader.make_response();
             recording_state_ctx.request_forced_file_offload();
             response.body.push_param("Requested offload of files from rp2040")?;
+            Ok(Some(response))
+        }
+        "prioritiseframeserve" => {
+            let mut response = msg.dynheader.make_response();
+            recording_state_ctx.request_prioritise_frames();
+            response.body.push_param("Requested priority frame serving from rp2040")?;
             Ok(Some(response))
         }
         _ => Ok(None),

--- a/src/device_config.rs
+++ b/src/device_config.rs
@@ -831,7 +831,12 @@ impl DeviceConfig {
         self.audio_info.audio_mode != AudioMode::AudioOnly
     }
 
-    pub fn write_to_slice(&self, output: &mut [u8], prefer_not_to_offload_files_now: bool) {
+    pub fn write_to_slice(
+        &self,
+        output: &mut [u8],
+        prefer_not_to_offload_files_now: bool,
+        force_offload_files_now: bool,
+    ) {
         let mut buf = Cursor::new(output);
         let device_id = self.device_id();
         buf.write_u32::<LittleEndian>(device_id).unwrap();
@@ -876,6 +881,7 @@ impl DeviceConfig {
         buf.write_all(&device_name[0..device_name_length]).unwrap();
         buf.write_u32::<LittleEndian>(self.audio_info.audio_seed).unwrap();
         buf.write_u8(if prefer_not_to_offload_files_now { 5 } else { 0 }).unwrap();
+        buf.write_u8(if force_offload_files_now { 1 } else { 0 }).unwrap();
     }
 }
 

--- a/src/device_config.rs
+++ b/src/device_config.rs
@@ -827,6 +827,10 @@ impl DeviceConfig {
         self.audio_info.audio_mode != AudioMode::Disabled
     }
 
+    pub fn is_thermal_device(&self) -> bool {
+        self.audio_info.audio_mode != AudioMode::AudioOnly
+    }
+
     pub fn write_to_slice(&self, output: &mut [u8], prefer_not_to_offload_files_now: bool) {
         let mut buf = Cursor::new(output);
         let device_id = self.device_id();
@@ -927,6 +931,7 @@ pub fn check_for_device_config_changes(
     device_config_change_channel_rx: &Receiver<DeviceConfig>,
     device_config: &mut DeviceConfig,
     is_audio_device: &mut bool,
+    is_thermal_device: &mut bool,
     rp2040_needs_reset: &mut bool,
 ) {
     // Check once per frame to see if the config file may have been changed
@@ -937,10 +942,8 @@ pub fn check_for_device_config_changes(
             if *device_config != config {
                 info!("Config updated, should update rp2040");
                 *device_config = config;
-                if !*is_audio_device {
-                    //will update after reset request if in audio mode
-                    *is_audio_device = device_config.is_audio_device();
-                }
+                *is_audio_device = device_config.is_audio_device();
+                *is_thermal_device = device_config.is_thermal_device();
             }
             *rp2040_needs_reset = true;
         }

--- a/src/device_config.rs
+++ b/src/device_config.rs
@@ -129,14 +129,11 @@ where
                                 }
                             }
                         }
-                        _ => error!(
-                            "Region '{}'[{}]: Expected array of [x, y] coordinates",
-                            label, i
-                        ),
+                        _ => error!("Region '{label}'[{i}]: Expected array of [x, y] coordinates",),
                     }
                 }
             }
-            _ => error!("Region '{}': Must be an array of [[x, y], ...] coordinates", label),
+            _ => error!("Region '{label}': Must be an array of [[x, y], ...] coordinates"),
         }
         regions.insert(label.clone(), region);
     }
@@ -657,7 +654,7 @@ impl DeviceConfig {
                 if device_config.audio_info.audio_mode != AudioMode::AudioOnly {
                     let inside_recording_window =
                         device_config.time_is_in_recording_window(&Utc::now().naive_utc());
-                    info!("Inside recording window: {}", inside_recording_window);
+                    info!("Inside recording window: {inside_recording_window}");
                     if !inside_recording_window {
                         device_config.print_next_recording_window(&Utc::now().naive_utc());
                     }
@@ -665,7 +662,7 @@ impl DeviceConfig {
                 Ok(device_config)
             }
             Err(msg) => {
-                error!("Toml parse error: {:?}", msg);
+                error!("Toml parse error: {msg:?}");
                 Err("Error deserializing TOML config")
             }
         }
@@ -811,8 +808,9 @@ impl DeviceConfig {
         let window_hours = window.num_hours();
         let window_mins = window.num_minutes() - (window_hours * 60);
         info!(
-            "Next recording window will start in {}h{}m and end in {}h{}m, window duration {}h{}m",
-            starts_in_hours, starts_in_mins, ends_in_hours, ends_in_mins, window_hours, window_mins
+            "Next recording window will start in {starts_in_hours}h{starts_in_mins}m \
+            and end in {ends_in_hours}h{ends_in_mins}m, \
+            window duration {window_hours}h{window_mins}m",
         );
     }
     pub fn time_is_in_recording_window(&self, date_time_utc: &NaiveDateTime) -> bool {
@@ -907,13 +905,13 @@ pub fn watch_local_config_file_changes(
                         }
                     }
                     Err(msg) => {
-                        error!("Load config error: {}", msg);
+                        error!("Load config error: {msg}");
                         process::exit(1);
                     }
                 }
             }
         }
-        Err(e) => error!("file watch error for /etc/cacophony/config.toml: {:?}", e),
+        Err(e) => error!("file watch error for /etc/cacophony/config.toml: {e:?}"),
     })
     .map_err(|e| {
         error!("{}", e);

--- a/src/device_config.rs
+++ b/src/device_config.rs
@@ -650,7 +650,7 @@ impl DeviceConfig {
                     // TODO: Event log error?
                     process::exit(1);
                 }
-                info!("Got config {:?}", device_config);
+                info!("Got config {device_config:?}");
                 if device_config.audio_info.audio_mode != AudioMode::AudioOnly {
                     let inside_recording_window =
                         device_config.time_is_in_recording_window(&Utc::now().naive_utc());
@@ -914,7 +914,7 @@ pub fn watch_local_config_file_changes(
         Err(e) => error!("file watch error for /etc/cacophony/config.toml: {e:?}"),
     })
     .map_err(|e| {
-        error!("{}", e);
+        error!("{e}");
         process::exit(1);
     })
     .unwrap();

--- a/src/device_config.rs
+++ b/src/device_config.rs
@@ -20,8 +20,8 @@ use std::str::FromStr;
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::{fs, process};
 use sun_times::sun_times;
-use toml::value::Offset;
 use toml::Value;
+use toml::value::Offset;
 
 fn default_constant_recorder() -> bool {
     false
@@ -106,10 +106,15 @@ where
                                 let mut y;
                                 for (idx, el) in coord.iter().enumerate() {
                                     let el_val = match &el {
-                                        Value::Float(float_val) => Some(*float_val as f64),
+                                        Value::Float(float_val) => Some(*float_val),
                                         Value::Integer(int_val) => Some(*int_val as f64),
                                         _ => {
-                                            error!("Region '{}'[{}].{}: Unsupported coordinate value, expected Float or Integer", label, i, if idx == 0 {'x'} else { 'y' });
+                                            error!(
+                                                "Region '{}'[{}].{}: Unsupported coordinate value, expected Float or Integer",
+                                                label,
+                                                i,
+                                                if idx == 0 { 'x' } else { 'y' }
+                                            );
                                             None
                                         }
                                     };
@@ -176,27 +181,26 @@ where
     for char in s.chars() {
         match char {
             '-' | '+' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => {
-                if let Some(NumberString(ref mut n, _, _)) = tokens.last_mut() {
+                if let Some(NumberString(n, _, _)) = tokens.last_mut() {
                     n.push(char);
                 } else {
                     tokens.push(NumberString(String::from(char), None, true));
                 }
             }
             's' | 'h' | 'm' | 'z' => {
-                if let Some(NumberString(_, ref mut o, _)) = tokens.last_mut() {
+                if let Some(NumberString(_, o, _)) = tokens.last_mut() {
                     *o = Some(TimeUnit(char));
                 } else {
                     // Parse error
                     return Err(Error::custom(format!(
-                        "Unexpected token in time string '{}': unit specifier before integer",
-                        s
+                        "Unexpected token in time string '{s}': unit specifier before integer"
                     )));
                 }
                 tokens.push(NumberString(String::from(""), None, true));
             }
             ':' => {
                 let count = tokens.len();
-                if let Some(NumberString(_, ref mut o, ref mut is_relative)) = tokens.last_mut() {
+                if let Some(NumberString(_, o, is_relative)) = tokens.last_mut() {
                     if count == 1 {
                         *o = Some(TimeUnit('h'));
                     } else if count == 2 {
@@ -208,17 +212,15 @@ where
                 } else {
                     // Parse error
                     return Err(Error::custom(format!(
-                        "Unexpected token in time string '{}': ':' before hour specifier",
-                        s
+                        "Unexpected token in time string '{s}': ':' before hour specifier"
                     )));
                 }
                 tokens.push(NumberString(String::from(""), None, false));
             }
             _ => {
                 return Err(Error::custom(format!(
-                    "Unexpected token in time string '{}': '{}'",
-                    s, char
-                )))
+                    "Unexpected token in time string '{s}': '{char}'"
+                )));
             }
         }
     }
@@ -229,13 +231,12 @@ where
             if relative_time_seconds.is_none() {
                 relative_time_seconds = Some(0);
             }
-        } else {
-            if absolute_time.is_none() {
-                absolute_time = Some(HourMin { hour: 0, min: 0 });
-            }
+        } else if absolute_time.is_none() {
+            absolute_time = Some(HourMin { hour: 0, min: 0 });
         }
+
         if let Some(ref mut seconds) = relative_time_seconds {
-            if let Ok(mut num) = i32::from_str_radix(&token.0, 10) {
+            if let Ok(mut num) = token.0.parse::<i32>() {
                 if let Some(unit) = &token.1 {
                     let mul = match unit.0 {
                         's' => 1,
@@ -254,7 +255,7 @@ where
                 }
             }
         } else if let Some(ref mut hour_min) = absolute_time {
-            if let Ok(num) = i32::from_str_radix(&token.0, 10) {
+            if let Ok(num) = token.0.parse::<i32>() {
                 if let Some(unit) = &token.1 {
                     match unit.0 {
                         'm' => hour_min.min = num as u8,
@@ -268,7 +269,7 @@ where
         }
     }
     if absolute_time.is_none() && relative_time_seconds.is_none() {
-        Err(Error::custom(format!("Failed to parse window time: {}", s)))
+        Err(Error::custom(format!("Failed to parse window time: {s}")))
     } else {
         Ok(AbsRelTime { absolute_time, relative_time_seconds })
     }
@@ -315,11 +316,7 @@ where
     D: Deserializer<'de>,
 {
     let location_accuracy: f32 = Deserialize::deserialize(deserializer)?;
-    if location_accuracy == 0.0 {
-        Ok(None)
-    } else {
-        Ok(Some(location_accuracy))
-    }
+    if location_accuracy == 0.0 { Ok(None) } else { Ok(Some(location_accuracy)) }
 }
 
 #[derive(Deserialize, Debug, PartialEq, Clone)]
@@ -334,7 +331,7 @@ struct LocationSettings {
     accuracy: Option<f32>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 struct HourMin {
     hour: u8,
     min: u8,
@@ -355,8 +352,8 @@ pub struct AbsRelTime {
 
 impl Debug for AbsRelTime {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let absolute_time = self.absolute_time.clone();
-        let relative_time = self.relative_time_seconds.clone();
+        let absolute_time = self.absolute_time;
+        let relative_time = self.relative_time_seconds;
         if let Some(time) = absolute_time {
             return f
                 .debug_struct("AbsoluteTime")
@@ -367,7 +364,7 @@ impl Debug for AbsRelTime {
         if let Some(time) = relative_time {
             return f.debug_struct("RelativeOffset").field("secs", &time).finish();
         }
-        Err(fmt::Error::default())
+        Err(fmt::Error)
     }
 }
 
@@ -426,9 +423,9 @@ pub enum AudioMode {
     AudioAndThermal = 3,
 }
 
-impl Into<u8> for AudioMode {
-    fn into(self) -> u8 {
-        self as u8
+impl From<AudioMode> for u8 {
+    fn from(audio_mode: AudioMode) -> u8 {
+        audio_mode as u8
     }
 }
 
@@ -495,7 +492,7 @@ where
     if let Ok(mode) = AudioMode::from_str(&audio_mode_raw) {
         Ok(mode)
     } else {
-        Err(Error::custom(format!("Failed to parse audio mode: {}", audio_mode_raw)))
+        Err(Error::custom(format!("Failed to parse audio mode: {audio_mode_raw}")))
     }
 }
 
@@ -628,6 +625,10 @@ impl DeviceConfig {
         self.recording_settings.use_low_power_mode
     }
 
+    pub fn use_high_power_mode(&self) -> bool {
+        !self.recording_settings.use_low_power_mode
+    }
+
     pub fn load_from_fs() -> Result<DeviceConfig, &'static str> {
         let config_toml =
             fs::read("/etc/cacophony/config.toml").map_err(|_| "Error reading file from disk")?;
@@ -639,8 +640,8 @@ impl DeviceConfig {
                 // TODO: Make sure device has sane windows etc.
                 if !device_config.has_location() {
                     error!(
-                "No location set for this device. To enter recording mode, a location must be set."
-            );
+                        "No location set for this device. To enter recording mode, a location must be set."
+                    );
                     // TODO: Event log error?
                     process::exit(1);
                 }
@@ -675,10 +676,10 @@ impl DeviceConfig {
             self.recording_window.start_recording.time_offset();
         let (is_absolute_end, mut end_offset) = self.recording_window.stop_recording.time_offset();
         if is_absolute_end && end_offset < 0 {
-            end_offset = 86_400 + end_offset;
+            end_offset += 86_400;
         }
         if is_absolute_start && start_offset < 0 {
-            start_offset = 86_400 + start_offset;
+            start_offset += 86_400;
         }
         let (window_start, window_end) = if !is_absolute_start || !is_absolute_end {
             let location =
@@ -765,7 +766,7 @@ impl DeviceConfig {
             let end_plus_one_day = end_time + Duration::days(1);
 
             if start_minus_one_day > end_minus_one_day {
-                end_minus_one_day = end_minus_one_day + Duration::days(1);
+                end_minus_one_day += Duration::days(1);
             }
             if start_plus_one_day > end_plus_one_day {
                 start_plus_one_day = start_time;
@@ -826,7 +827,7 @@ impl DeviceConfig {
         self.audio_info.audio_mode != AudioMode::Disabled
     }
 
-    pub fn write_to_slice(&self, output: &mut [u8]) {
+    pub fn write_to_slice(&self, output: &mut [u8], prefer_not_to_offload_files_now: bool) {
         let mut buf = Cursor::new(output);
         let device_id = self.device_id();
         buf.write_u32::<LittleEndian>(device_id).unwrap();
@@ -868,8 +869,9 @@ impl DeviceConfig {
         let device_name = self.device_name();
         let device_name_length = device_name.len().min(63);
         buf.write_u8(device_name_length as u8).unwrap();
-        buf.write(&device_name[0..device_name_length]).unwrap();
+        buf.write_all(&device_name[0..device_name_length]).unwrap();
         buf.write_u32::<LittleEndian>(self.audio_info.audio_seed).unwrap();
+        buf.write_u8(if prefer_not_to_offload_files_now { 5 } else { 0 }).unwrap();
     }
 }
 
@@ -880,28 +882,25 @@ pub fn watch_local_config_file_changes(
     let config_tx = config_tx.clone();
     let mut watcher = notify::recommended_watcher(move |res| match res {
         Ok(Event { kind, .. }) => {
-            match kind {
-                EventKind::Access(AccessKind::Close(AccessMode::Write)) => {
-                    // File got written to
-                    // Send event to
-                    match DeviceConfig::load_from_fs() {
-                        Ok(config) => {
-                            // Send to rp2040 to write via a channel somehow.
-                            // Maybe we have to restart the rp2040 here so that it re-handshakes
-                            // and picks up the new info
-                            if config != current_config {
-                                current_config = config;
-                                warn!("Config updated");
-                                let _ = config_tx.send(current_config.clone());
-                            }
-                        }
-                        Err(msg) => {
-                            error!("Load config error: {}", msg);
-                            process::exit(1);
+            if let EventKind::Access(AccessKind::Close(AccessMode::Write)) = kind {
+                // File got written to
+                // Send event to
+                match DeviceConfig::load_from_fs() {
+                    Ok(config) => {
+                        // Send to rp2040 to write via a channel somehow.
+                        // Maybe we have to restart the rp2040 here so that it re-handshakes
+                        // and picks up the new info
+                        if config != current_config {
+                            current_config = config;
+                            warn!("Config updated");
+                            let _ = config_tx.send(current_config.clone());
                         }
                     }
+                    Err(msg) => {
+                        error!("Load config error: {}", msg);
+                        process::exit(1);
+                    }
                 }
-                _ => {}
             }
         }
         Err(e) => error!("file watch error for /etc/cacophony/config.toml: {:?}", e),

--- a/src/double_buffer.rs
+++ b/src/double_buffer.rs
@@ -1,7 +1,7 @@
 use crate::cptv_frame_dispatch::Frame;
 use std::cell::RefCell;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub struct DoubleBuffer {
     pub front: Mutex<RefCell<Option<Frame>>>,
@@ -24,19 +24,11 @@ impl DoubleBuffer {
 
     pub fn get_front(&self) -> &Mutex<RefCell<Option<Frame>>> {
         let val = self.swapper.load(Ordering::Acquire);
-        if val % 2 == 0 {
-            &self.front
-        } else {
-            &self.back
-        }
+        if val % 2 == 0 { &self.front } else { &self.back }
     }
 
     pub fn get_back(&self) -> &Mutex<RefCell<Option<Frame>>> {
         let val = self.swapper.load(Ordering::Acquire);
-        if val % 2 == 0 {
-            &self.back
-        } else {
-            &self.front
-        }
+        if val % 2 == 0 { &self.back } else { &self.front }
     }
 }

--- a/src/frame_socket_server.rs
+++ b/src/frame_socket_server.rs
@@ -2,13 +2,13 @@ use crate::camera_transfer_state::CameraHandshakeInfo;
 use crate::cptv_frame_dispatch;
 use crate::program_rp2040::program_rp2040;
 use crate::recording_state::{RecordingMode, RecordingState};
-use crate::socket_stream::{get_socket_address, SocketStream};
-use crate::telemetry::{read_telemetry, Telemetry};
+use crate::socket_stream::{SocketStream, get_socket_address};
+use crate::telemetry::{Telemetry, read_telemetry};
 use log::{debug, error, info, warn};
 use rppal::gpio::OutputPin;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
-use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 use std::{process, thread};
@@ -25,7 +25,7 @@ fn restart_rp2040_if_requested(
     restart_rp2040_ack: &mut Arc<AtomicBool>,
 ) {
     // Check if we need to reset rp2040 because of a config change
-    if let Ok(_) = restart_rp2040_channel_rx.try_recv() {
+    if restart_rp2040_channel_rx.try_recv().is_ok() {
         restart_rp2040_ack.store(true, Ordering::Relaxed);
         info!("Restarting rp2040");
         if !run_pin.is_set_high() {
@@ -47,9 +47,9 @@ pub fn spawn_frame_socket_server_thread(
     recording_state: &RecordingState,
 ) {
     let recording_state = recording_state.clone();
-    let _ = thread::Builder::new()
-        .name("frame-socket".to_string())
-        .spawn_with_priority(ThreadPriority::Max, move |result| {
+    let _ = thread::Builder::new().name("frame-socket".to_string()).spawn_with_priority(
+        ThreadPriority::Max,
+        move |result| {
             let address = get_socket_address(serve_frames_via_wifi);
             let management_address = "/var/spool/managementd".to_string();
             // Spawn a thread which can output the frames, converted to rgb grayscale
@@ -63,60 +63,56 @@ pub fn spawn_frame_socket_server_thread(
 
             let mut reconnects = 0;
             let mut prev_frame_num = None;
-            let mut sockets: [(String, bool, Option<SocketStream>); 2] = [
-                (address, serve_frames_via_wifi, None),
-                (management_address, false, None),
-            ];
+            let mut sockets: [(String, bool, Option<SocketStream>); 2] =
+                [(address, serve_frames_via_wifi, None), (management_address, false, None)];
+
+            restart_rp2040_if_requested(
+                &restart_rp2040_channel_rx,
+                &mut run_pin,
+                &mut restart_rp2040_ack,
+            );
+            let mut recv_timeout_ms = 10;
+            info!("Connecting to frame sockets");
+            let mut ms_elapsed = 0;
             loop {
                 restart_rp2040_if_requested(
                     &restart_rp2040_channel_rx,
                     &mut run_pin,
                     &mut restart_rp2040_ack,
                 );
-                let mut recv_timeout_ms = 10;
-                info!("Connecting to frame sockets");
-                let mut ms_elapsed = 0;
-                loop {
-                    restart_rp2040_if_requested(
-                        &restart_rp2040_channel_rx,
-                        &mut run_pin,
-                        &mut restart_rp2040_ack,
-                    );
-                    if recording_state.recording_mode() == RecordingMode::Thermal {
-                        for (address, use_wifi, stream) in
-                            sockets.iter_mut().filter(|(_, _, stream)| stream.is_none())
-                        {
-                            let stream_connection: Option<SocketStream> =
-                                SocketStream::from_address(&address, *use_wifi).ok();
-                            if stream_connection.is_some() {
-                                println!("Connected to {}", &address);
-                            }
-                            *stream = stream_connection;
+                if recording_state.recording_mode() == RecordingMode::Thermal {
+                    for (address, use_wifi, stream) in
+                        sockets.iter_mut().filter(|(_, _, stream)| stream.is_none())
+                    {
+                        let stream_connection: Option<SocketStream> =
+                            SocketStream::from_address(address, *use_wifi).ok();
+                        if stream_connection.is_some() {
+                            println!("Connected to {address}");
                         }
-
-                        let connections = sockets
-                            .iter()
-                            .filter(|(_, _, stream)| stream.is_some())
-                            .count();
-                        if connections == 0 {
-                            sleep(Duration::from_millis(1000));
-                            continue;
-                        }
+                        *stream = stream_connection;
                     }
 
-                    handle_payload_from_frame_acquire_thread(
-                        camera_handshake_channel_rx
-                            .recv_timeout(Duration::from_millis(recv_timeout_ms)),
-                        &mut sockets,
-                        &mut ms_elapsed,
-                        &mut reconnects,
-                        &mut prev_frame_num,
-                        &recording_state,
-                        &mut recv_timeout_ms,
-                    );
+                    let connections =
+                        sockets.iter().filter(|(_, _, stream)| stream.is_some()).count();
+                    if connections == 0 {
+                        sleep(Duration::from_millis(1000));
+                        continue;
+                    }
                 }
+
+                handle_payload_from_frame_acquire_thread(
+                    camera_handshake_channel_rx
+                        .recv_timeout(Duration::from_millis(recv_timeout_ms)),
+                    &mut sockets,
+                    &mut ms_elapsed,
+                    &mut reconnects,
+                    &mut prev_frame_num,
+                    &recording_state,
+                    &mut recv_timeout_ms,
+                );
             }
-        });
+        },
+    );
 }
 
 fn handle_payload_from_frame_acquire_thread(
@@ -139,11 +135,7 @@ fn handle_payload_from_frame_acquire_thread(
                 }),
             camera_file_transfer_in_progress: false,
         }) => {
-            let model = if radiometry_enabled {
-                "lepton3.5"
-            } else {
-                "lepton3"
-            };
+            let model = if radiometry_enabled { "lepton3.5" } else { "lepton3" };
             let header = format!(
                 "ResX: 160\n\
                         ResX: 160\n\
@@ -158,9 +150,7 @@ fn handle_payload_from_frame_acquire_thread(
             for (_, _, stream) in sockets.iter_mut().filter(|(_, use_wifi, stream)| {
                 stream.is_some() && !use_wifi && !stream.as_ref().unwrap().sent_header
             }) {
-                let stream = stream
-                    .as_mut()
-                    .expect("Never fails, because we filtered already.");
+                let stream = stream.as_mut().expect("Never fails, because we filtered already.");
                 if stream.write_all(header.as_bytes()).is_err() {
                     warn!("Failed sending header info");
                 }
@@ -190,11 +180,7 @@ fn handle_payload_from_frame_acquire_thread(
                     if !sent {
                         warn!(
                             "Send to {} failed",
-                            if *use_wifi {
-                                "tc2-frames server"
-                            } else {
-                                address
-                            }
+                            if *use_wifi { "tc2-frames server" } else { address }
                         );
                         let _ = stream.take().expect("Never fails").shutdown().is_ok();
                     }
@@ -206,17 +192,15 @@ fn handle_payload_from_frame_acquire_thread(
             }
             if let Some(telemetry) = telemetry {
                 if let Some(prev_frame_num) = prev_frame_num {
-                    if !telemetry.ffc_in_progress {
-                        if telemetry.frame_num != *prev_frame_num + 1 {
-                            // NOTE: Frames can be missed when the raspberry pi
-                            //  blocks the thread with the
-                            //  unix socket in `thermal-recorder`.
-                            debug!(
-                                "Missed {} frames after {}s on",
-                                telemetry.frame_num - (*prev_frame_num + 1),
-                                telemetry.msec_on as f32 / 1000.0
-                            );
-                        }
+                    if !telemetry.ffc_in_progress && telemetry.frame_num != *prev_frame_num + 1 {
+                        // NOTE: Frames can be missed when the raspberry pi
+                        //  blocks the thread with the
+                        //  unix socket in `thermal-recorder`.
+                        debug!(
+                            "Missed {} frames after {}s on",
+                            telemetry.frame_num - (*prev_frame_num + 1),
+                            telemetry.msec_on as f32 / 1000.0
+                        );
                     }
                 }
                 *prev_frame_num = Some(telemetry.frame_num);
@@ -240,11 +224,7 @@ fn handle_payload_from_frame_acquire_thread(
                     {
                         info!(
                             "Shutting down socket '{}'",
-                            if *use_wifi {
-                                "tc2-frames server"
-                            } else {
-                                address
-                            }
+                            if *use_wifi { "tc2-frames server" } else { address }
                         );
                         let _ = stream.take().unwrap().shutdown().is_ok();
                     }

--- a/src/frame_socket_server.rs
+++ b/src/frame_socket_server.rs
@@ -58,7 +58,8 @@ pub fn spawn_frame_socket_server_thread(
             // This is printed out from within the spawned thread.
             if result.is_err() {
                 error!(
-                    "Thread must have permissions to run with realtime priority, run as root user"
+                    "Thread must have permissions to run with realtime priority, \
+                    run as root user"
                 );
                 process::exit(1);
             }
@@ -190,7 +191,7 @@ fn handle_payload_from_frame_acquire_thread(
             }
             let e = s.elapsed().as_secs_f32();
             if e > 0.1 {
-                info!("socket send took {}s", e);
+                info!("socket send took {e}s");
             }
             if let Some(telemetry) = telemetry {
                 if let Some(prev_frame_num) = prev_frame_num {

--- a/src/frame_socket_server.rs
+++ b/src/frame_socket_server.rs
@@ -24,6 +24,8 @@ fn restart_rp2040_if_requested(
     run_pin: &mut OutputPin,
     restart_rp2040_ack: &mut Arc<AtomicBool>,
 ) {
+    // FIXME: Check if the rp2040 recording flag is set before restarting.
+
     // Check if we need to reset rp2040 because of a config change
     if restart_rp2040_channel_rx.try_recv().is_ok() {
         restart_rp2040_ack.store(true, Ordering::Relaxed);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::all)]
 extern crate core;
 
 mod camera_transfer_state;
@@ -86,8 +87,8 @@ fn check_for_sufficient_free_disk_space() {
         if mb_remaining < 1000 {
             if !warned_once {
                 warn!(
-                    "Insufficient disk space remaining: ({}MB/{}MB), sleeping 1 minute before trying again.",
-                    mb_remaining, mb_total
+                    "Insufficient disk space remaining: ({mb_remaining}MB/{mb_total}MB), \
+                    sleeping 1 minute before trying again.",
                 );
                 warned_once = true;
             }
@@ -124,15 +125,15 @@ fn main() {
     }
 
     let session_path = get_system_bus_path().unwrap_or_else(|e| {
-        error!("Error getting system DBus: {}", e);
+        error!("Error getting system DBus: {e}");
         process::exit(1);
     });
     let mut dbus_conn = DuplexConn::connect_to_bus(session_path, true).unwrap_or_else(|e| {
-        error!("Error connecting to system DBus: {}", e);
+        error!("Error connecting to system DBus: {e}");
         process::exit(1);
     });
     let _unique_name: String = dbus_conn.send_hello(Timeout::Infinite).unwrap_or_else(|e| {
-        error!("Error getting handshake with system DBus: {}", e);
+        error!("Error getting handshake with system DBus: {e}");
         process::exit(1);
     });
 
@@ -216,7 +217,7 @@ fn main() {
         .unwrap();
 
     if let Err(e) = handle.join() {
-        error!("Thread panicked: {:?}", e);
+        error!("Thread panicked: {e:?}");
         process::exit(1);
     }
 }

--- a/src/program_rp2040.rs
+++ b/src/program_rp2040.rs
@@ -10,14 +10,10 @@ pub fn program_rp2040() -> io::Result<()> {
     let hash = sha256::digest(&bytes);
     let expected_hash = EXPECTED_RP2040_FIRMWARE_HASH.trim();
     if hash != expected_hash {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "rp2040-firmware.elf does not match \
-        expected hash. Expected: '{}', Calculated: '{}'",
-                expected_hash, hash
-            ),
-        ));
+        return Err(io::Error::other(format!(
+            "rp2040-firmware.elf does not match \
+        expected hash. Expected: '{expected_hash}', Calculated: '{hash}'",
+        )));
     }
     let status = Command::new("tc2-hat-rp2040")
         .arg("--elf")
@@ -25,7 +21,7 @@ pub fn program_rp2040() -> io::Result<()> {
         .status()?;
 
     if !status.success() {
-        return Err(io::Error::new(io::ErrorKind::Other, "Command execution failed"));
+        return Err(io::Error::other("Command execution failed"));
     }
 
     info!("Updated RP2040 firmware.");

--- a/src/program_rp2040.rs
+++ b/src/program_rp2040.rs
@@ -41,8 +41,7 @@ pub fn check_if_rp2040_needs_programming() {
                 Err(e) => {
                     error!(
                         "Failed to remove 'program_rp2040' \
-                        file after successful reprogram: {}",
-                        e
+                        file after successful reprogram: {e}"
                     );
                     process::exit(1);
                 }

--- a/src/recording_state.rs
+++ b/src/recording_state.rs
@@ -586,7 +586,7 @@ impl RecordingState {
         let new_state = state | state_bits_to_set;
         dbus_write_attiny_command(conn, ATTINY_REG_TC2_AGENT_STATE, new_state)
             .map_err(|msg: &str| -> Result<(), String> {
-                error!("{}", msg);
+                error!("{msg}");
                 process::exit(1);
             })
             .ok();

--- a/src/save_audio.rs
+++ b/src/save_audio.rs
@@ -68,11 +68,8 @@ pub fn save_audio_file_to_disk(mut audio_bytes: Vec<u8>, device_config: DeviceCo
                 fs::create_dir(&debug_dir).unwrap_or_else(|_| {
                     panic!("Failed to create debug output directory {debug_dir}")
                 });
-                let output_path: String = format!(
-                    "{}/{}.raw",
-                    debug_dir,
-                    recording_date_time.format("%Y-%m-%d--%H-%M-%S")
-                );
+                let output_path: String =
+                    format!("{debug_dir}/{}.raw", recording_date_time.format("%Y-%m-%d--%H-%M-%S"));
                 fs::write(&output_path, &audio_bytes).unwrap();
             }
 
@@ -142,7 +139,7 @@ pub fn save_audio_file_to_disk(mut audio_bytes: Vec<u8>, device_config: DeviceCo
                 args.push("-f");
                 args.push("mp4");
                 args.push(&output_path);
-                info!("Saving AAC file with args {:#?}", args);
+                info!("Saving AAC file with args {args:#?}");
 
                 // Now transcode with ffmpeg – we create an aac stream in an m4a wrapper in order
                 // to support adding metadata tags.
@@ -155,7 +152,7 @@ pub fn save_audio_file_to_disk(mut audio_bytes: Vec<u8>, device_config: DeviceCo
                 {
                     Ok(child) => child,
                     Err(e) => {
-                        error!("Failed to spawn ffmpeg process for {:?}: {}", output_path, e);
+                        error!("Failed to spawn ffmpeg process for {output_path:?}: {e}");
                         return;
                     }
                 };
@@ -179,7 +176,7 @@ pub fn save_audio_file_to_disk(mut audio_bytes: Vec<u8>, device_config: DeviceCo
                 match cmd.wait() {
                     Ok(exit_status) => {
                         if exit_status.success() {
-                            info!("Saved AAC file {}", output_path);
+                            info!("Saved AAC file {output_path}");
                         } else {
                             let mut stderr = match cmd.stderr.take() {
                                 Some(stderr) => stderr,
@@ -191,20 +188,16 @@ pub fn save_audio_file_to_disk(mut audio_bytes: Vec<u8>, device_config: DeviceCo
                             let mut buffer = String::new();
                             let _ = stderr.read_to_string(&mut buffer);
                             error!(
-                                "Failed transcoding {} to AAC ffmpeg output {}",
-                                output_path, buffer
+                                "Failed transcoding {output_path} to AAC ffmpeg output {buffer}",
                             );
                         }
                     }
                     Err(e) => {
-                        error!(
-                            "Failed invoking ffmpeg to transcode {}, reason: {}",
-                            output_path, e
-                        );
+                        error!("Failed invoking ffmpeg to transcode {output_path}, reason: {e}",);
                     }
                 }
             } else {
-                error!("File {} already exists, discarding duplicate", output_path);
+                error!("File {output_path} already exists, discarding duplicate");
             }
         },
     );

--- a/src/save_cptv.rs
+++ b/src/save_cptv.rs
@@ -14,7 +14,7 @@ pub fn save_cptv_file_to_disk(mut cptv_bytes: Vec<u8>, output_dir: &str) {
         move |_| match decode_cptv_header_streaming(&cptv_bytes) {
             Ok(header) => match header {
                 CptvHeader::V2(header) => {
-                    info!("Saving CPTV file with header {:?}", header);
+                    info!("Saving CPTV file with header {header:?}");
                     let recording_date_time =
                         DateTime::from_timestamp_millis(header.timestamp as i64 / 1000)
                             .unwrap_or(chrono::Local::now().with_timezone(&Utc))
@@ -44,12 +44,11 @@ pub fn save_cptv_file_to_disk(mut cptv_bytes: Vec<u8>, output_dir: &str) {
                     if !is_existing_file {
                         match fs::write(&path, &cptv_bytes) {
                             Ok(()) => {
-                                info!("Saved CPTV file {}", path);
+                                info!("Saved CPTV file {path}");
                             }
                             Err(e) => {
                                 error!(
-                                    "Failed writing CPTV file to storage at {}, reason: {}",
-                                    path, e
+                                    "Failed writing CPTV file to storage at {path}, reason: {e}"
                                 );
                             }
                         }
@@ -72,13 +71,13 @@ pub fn save_cptv_file_to_disk(mut cptv_bytes: Vec<u8>, output_dir: &str) {
                         //     }
                         // }
                     } else {
-                        error!("File {} already exists, discarding duplicate", path);
+                        error!("File {path} already exists, discarding duplicate");
                     }
                 }
                 _ => error!("Unsupported CPTV file format, discarding file"),
             },
             Err(e) => {
-                error!("Invalid CPTV file: ({:?}), discarding", e);
+                error!("Invalid CPTV file: ({e:?}), discarding");
             }
         },
     );

--- a/src/save_cptv.rs
+++ b/src/save_cptv.rs
@@ -1,10 +1,6 @@
-use crate::cptv_header::{decode_cptv_header_streaming, CptvHeader};
+use crate::cptv_header::{CptvHeader, decode_cptv_header_streaming};
 use chrono::{DateTime, Utc};
-use flate2::read::GzEncoder;
-use flate2::read::MultiGzDecoder;
-use flate2::Compression;
 use log::{error, info};
-use std::io::prelude::*;
 use std::{fs, thread};
 use thread_priority::{ThreadBuilderExt, ThreadPriority};
 
@@ -24,14 +20,12 @@ pub fn save_cptv_file_to_disk(mut cptv_bytes: Vec<u8>, output_dir: &str) {
                             .unwrap_or(chrono::Local::now().with_timezone(&Utc))
                             .with_timezone(&chrono::Local);
                     if !fs::exists(&output_dir).unwrap_or(false) {
-                        fs::create_dir(&output_dir)
-                            .expect(&format!("Failed to create output directory {}", output_dir));
+                        fs::create_dir(&output_dir).unwrap_or_else(|_| {
+                            panic!("Failed to create output directory {output_dir}")
+                        });
                     }
-                    let path = format!(
-                        "{}/{}.cptv",
-                        output_dir,
-                        recording_date_time.format("%Y-%m-%d--%H-%M-%S")
-                    );
+                    let filename = recording_date_time.format("%Y-%m-%d--%H-%M-%S");
+                    let path = format!("{output_dir}/{filename}.cptv",);
                     //very slow and cpu intensive offered 18% saving on a 10 minute recording
                     // let decoder = MultiGzDecoder::new(&cptv_bytes[..]);
                     // let mut encoder = GzEncoder::new(decoder, Compression::default());

--- a/src/socket_stream.rs
+++ b/src/socket_stream.rs
@@ -79,7 +79,7 @@ pub fn get_socket_address(serve_frames_via_wifi: bool) -> String {
                 if let ServiceEvent::ServiceResolved(info) = event {
                     if let Some(add) = info.get_addresses().iter().next() {
                         address = Some(add.to_string());
-                        info!("Resolved a tc2-frames service at: {:?}", add);
+                        info!("Resolved a tc2-frames service at: {add:?}");
                         break 'service_finder;
                     }
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,18 +1,10 @@
 pub fn u8_slice_as_u16_slice(p: &[u8]) -> &[u16] {
-    assert_eq!(
-        (p.len() / 2) * 2,
-        p.len(),
-        "slice must be evenly divisible by 2"
-    );
+    assert_eq!((p.len() / 2) * 2, p.len(), "slice must be evenly divisible by 2");
     unsafe { core::slice::from_raw_parts((p as *const [u8]) as *const u16, p.len() / 2) }
 }
 
 #[allow(unused)]
 pub fn u8_slice_as_u16_slice_mut(p: &mut [u8]) -> &mut [u16] {
-    assert_eq!(
-        (p.len() / 2) * 2,
-        p.len(),
-        "slice must be evenly divisible by 2"
-    );
+    assert_eq!((p.len() / 2) * 2, p.len(), "slice must be evenly divisible by 2");
     unsafe { core::slice::from_raw_parts_mut((p as *mut [u8]) as *mut u16, p.len() / 2) }
 }


### PR DESCRIPTION
This changeset supports the changes to the rp2040 firmware, mostly around being able to cancel in-flight file offloads and request prioritisation of camera preview.

It also adds the ability to request low power mode thermal test recordings.

Also added clippy for linting.

The initial camera handshake is now two-stage, since we have an initial handshake on rp2040 startup, and another when we enter one of the two recording modes, and get information about the lepton sensor (in thermal mode).

Updated rust toolchain and edition.