### PR TITLE
r26: Device config synchronisation robustness.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      RP2040_FIRMWARE_VERSION: 0.2.27
+      RP2040_FIRMWARE_VERSION: 0.2.28
 
     steps:
       - name: Checkout repository
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88.0
+          toolchain: 1.89.0
           override: true
           components: rustfmt, clippy
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
-msrv = "1.88.0"
+msrv = "1.89.0"
 too-many-arguments-threshold = 15

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"  # If changing this then also change it in .github/workflows/release.yaml rust toolchain
+channel = "1.89.0"  # If changing this then also change it in .github/workflows/release.yaml rust toolchain
 targets = ["aarch64-unknown-linux-musl"]

--- a/src/frame_socket_server.rs
+++ b/src/frame_socket_server.rs
@@ -194,18 +194,20 @@ fn handle_payload_from_frame_acquire_thread(
                 info!("socket send took {e}s");
             }
             if let Some(telemetry) = telemetry {
-                if let Some(prev_frame_num) = prev_frame_num {
-                    if !telemetry.ffc_in_progress && telemetry.frame_num != *prev_frame_num + 1 {
-                        // NOTE: Frames can be missed when the raspberry pi
-                        //  blocks the thread with the
-                        //  unix socket in `thermal-recorder`.
-                        debug!(
-                            "Missed {} frames after {}s on",
-                            telemetry.frame_num - (*prev_frame_num + 1),
-                            telemetry.msec_on as f32 / 1000.0
-                        );
-                    }
+                if let Some(prev_frame_num) = prev_frame_num
+                    && !telemetry.ffc_in_progress
+                    && telemetry.frame_num != *prev_frame_num + 1
+                {
+                    // NOTE: Frames can be missed when the raspberry pi
+                    //  blocks the thread with the
+                    //  unix socket in `thermal-recorder`.
+                    debug!(
+                        "Missed {} frames after {}s on",
+                        telemetry.frame_num - (*prev_frame_num + 1),
+                        telemetry.msec_on as f32 / 1000.0
+                    );
                 }
+
                 *prev_frame_num = Some(telemetry.frame_num);
                 if telemetry.frame_num % 2700 == 0 {
                     info!("Got frame #{}", telemetry.frame_num);

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ use crate::recording_state::RecordingState;
 const AUDIO_SHEBANG: u16 = 1;
 
 const EXPECTED_RP2040_FIRMWARE_HASH: &str = include_str!("../_releases/tc2-firmware.sha256");
-const EXPECTED_RP2040_FIRMWARE_VERSION: u32 = 25;
+const EXPECTED_RP2040_FIRMWARE_VERSION: u32 = 26;
 const EXPECTED_ATTINY_FIRMWARE_VERSION: u8 = 1;
 
 const SEGMENT_LENGTH: usize = 9760;

--- a/src/socket_stream.rs
+++ b/src/socket_stream.rs
@@ -76,12 +76,12 @@ pub fn get_socket_address(serve_frames_via_wifi: bool) -> String {
         );
         'service_finder: loop {
             while let Ok(event) = receiver.recv() {
-                if let ServiceEvent::ServiceResolved(info) = event {
-                    if let Some(add) = info.get_addresses().iter().next() {
-                        address = Some(add.to_string());
-                        info!("Resolved a tc2-frames service at: {add:?}");
-                        break 'service_finder;
-                    }
+                if let ServiceEvent::ServiceResolved(info) = event
+                    && let Some(add) = info.get_addresses().iter().next()
+                {
+                    address = Some(add.to_string());
+                    info!("Resolved a tc2-frames service at: {add:?}");
+                    break 'service_finder;
                 }
             }
         }


### PR DESCRIPTION
- Make sure that we clear out the entire channel of any pending new device configurations before applying the last one.
- Send CRC information with the device config that's sent to the RP2040.
- Validate that the RP2040 sends the same CRC back once it's received a new device config.
- Update to latest Rust Toolchain version.
- Apply new clippy lint suggestions.