### PR TITLE
- Fixes incorrectly not adding appropriate metadata for test recordings.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       RP2040_FIRMWARE_VERSION: 0.5.1
@@ -22,10 +22,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.90.0
-          override: true
           components: rustfmt, clippy
 
       - name: Display Rust and Cargo version

--- a/src/save_audio.rs
+++ b/src/save_audio.rs
@@ -105,7 +105,10 @@ pub fn save_audio_file_to_disk(mut audio_bytes: Vec<u8>, device_config: DeviceCo
                 let duration_seconds = audio_bytes[12..].len() as f32 / sample_rate as f32 / 2.0;
                 let duration = format!("duration={duration_seconds}");
                 let sr = format!("originalSampleRate={original_sample_rate}");
-                let is_test_recording = duration_seconds < 3.0;
+                // If it's a short user-requested test recording, or a 5 minute bird count, mark
+                // it in the metadata
+                let is_test_recording = duration_seconds < 11.0;
+                let is_5_minute_bird_count = duration_seconds > 60.0 * 4.0;
                 let mut args = Vec::from([
                     "-i",
                     "pipe:0",
@@ -140,7 +143,7 @@ pub fn save_audio_file_to_disk(mut audio_bytes: Vec<u8>, device_config: DeviceCo
                     "-metadata",
                     &sr,
                 ]);
-                if is_test_recording {
+                if is_test_recording || is_5_minute_bird_count {
                     args.push("-metadata");
                     args.push("testRecording=true");
                 }


### PR DESCRIPTION
Previously we were incorrectly only setting the test recording status in the audio metadata if the duration was less than 3 seconds, but audio test recordings are always ~10 seconds for user requested test, and ~5 minutes for user requested bird count recording.